### PR TITLE
Remove extra search bar and period films button

### DIFF
--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -1,8 +1,5 @@
 import React from 'react';
 import './App.css';
-import SearchBar from './components/SearchBar';
-import DecadeSelector from './components/DecadeSelector';
-import YearSelector from './components/YearSelector';
 import ResultList from './components/ResultList';
 import { useSearch } from './hooks/useSearch';
 import HeroBanner from './components/HeroBanner';
@@ -14,12 +11,7 @@ function App() {
     platforms,
     scores,
     loading,
-    selectedDecade, setSelectedDecade,
-    selectedYear,
-    showDecades, setShowDecades,
-    decades,
-    handleSearch,
-    handleYearSelect
+    handleSearch
   } = useSearch();
 
   // HeroBanner'dan gelen arama işlemi
@@ -28,74 +20,13 @@ function App() {
     handleSearch(searchQuery);
   };
 
-  // Dönem seçimi
-  const handleShowDecades = () => {
-    setShowDecades(!showDecades);
-  };
-
   return (
     <div className="App" style={{ backgroundColor: 'black', color: 'white', minHeight: '100vh', padding: '20px' }}>
       {/* Sinematik HeroBanner */}
-      <HeroBanner 
-        title="Tüm platformlarda sinemanın en iyileri!" 
+      <HeroBanner
+        title="Tüm platformlarda sinemanın en iyileri!"
         onSearch={handleHeroSearch}
       />
-      
-      {/* Alt kısımdaki ikincil arama ve dönem seçici */}
-      <div style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        marginBottom: '24px',
-        marginTop: '30px',
-        maxWidth: '1200px',
-        margin: '30px auto 24px',
-        padding: '0 20px'
-      }}>
-        <div style={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
-          <SearchBar 
-            query={query} 
-            setQuery={setQuery} 
-            onSearch={() => handleSearch(query)} 
-          />
-        </div>
-        <div style={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
-          <button
-            onClick={handleShowDecades}
-            style={{
-              padding: '10px 20px',
-              fontSize: '15px',
-              backgroundColor: showDecades ? '#00ff88' : '#222',
-              color: showDecades ? '#0a0a0a' : 'white',
-              border: '1px solid #555',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              fontWeight: '500',
-              transition: 'all 0.3s ease'
-            }}
-          >
-            Dönem Filmleri {showDecades ? '✕' : '▾'}
-          </button>
-        </div>
-      </div>
-
-      {/* Dönem seçiciler */}
-      {showDecades && (
-        <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 20px' }}>
-          <DecadeSelector
-            decades={decades}
-            selectedDecade={selectedDecade}
-            onSelectDecade={setSelectedDecade}
-          />
-          {selectedDecade && (
-            <YearSelector
-              selectedDecade={selectedDecade}
-              selectedYear={selectedYear}
-              onSelectYear={handleYearSelect}
-            />
-          )}
-        </div>
-      )}
 
       {/* Yükleniyor durumu */}
       {loading && (

--- a/watchy-frontend/src/App.test.js
+++ b/watchy-frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders hero banner login button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const loginButton = screen.getByText(/Giriş Yap/i);
+  expect(loginButton).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- Simplify home page to only show hero banner, results and loading indicator
- Drop duplicate bottom search bar and period films toggle
- Update test to look for login button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6df6ac33c8323a0003aa70154785b