### PR TITLE
Add Hollywood decade cards and update TMDB queries

### DIFF
--- a/watchy-backend/routes/searchByPeriod.js
+++ b/watchy-backend/routes/searchByPeriod.js
@@ -28,13 +28,13 @@ router.get('/', async (req, res) => {
       const response = await axios.get('https://api.themoviedb.org/3/discover/movie', {
         params: {
           api_key: TMDB_API_KEY,
-          language: 'tr-TR',
+          language: 'en-US',
           sort_by: 'popularity.desc',
           include_adult: false,
           page,
           primary_release_date_gte: `${from}-01-01`,
           primary_release_date_lte: `${to}-12-31`,
-          with_origin_country: 'TR'
+          with_origin_country: 'US'
         }
       });
 

--- a/watchy-backend/routes/searchByYear.js
+++ b/watchy-backend/routes/searchByYear.js
@@ -17,10 +17,10 @@ router.get('/:year', async (req, res) => {
       const response = await axios.get('https://api.themoviedb.org/3/discover/movie', {
         params: {
           api_key: TMDB_API_KEY,
-          language: 'tr-TR',
+          language: 'en-US',
           sort_by: 'popularity.desc',
           include_adult: false,
-          with_origin_country: 'TR',
+          with_origin_country: 'US',
           page,
           primary_release_year: year
         }

--- a/watchy-backend/services/tmdbService.js
+++ b/watchy-backend/services/tmdbService.js
@@ -34,8 +34,8 @@ async function searchMoviesWithCredits(query) {
       const response = await axios.get('https://api.themoviedb.org/3/discover/movie', {
         params: {
           api_key: TMDB_API_KEY,
-          with_origin_country: 'TR',
-          language: 'tr-TR',
+          with_origin_country: 'US',
+          language: 'en-US',
           include_adult: false,
           sort_by: sort,
           page
@@ -77,14 +77,14 @@ async function getWatchProviders(movieId) {
     params: { api_key: TMDB_API_KEY }
   });
   return {
-    platforms: res.data?.results?.TR?.flatrate || [],
-    link: res.data?.results?.TR?.link || ''
+    platforms: res.data?.results?.US?.flatrate || [],
+    link: res.data?.results?.US?.link || ''
   };
 }
 
 async function getMovieTitle(movieId) {
   const res = await axios.get(`https://api.themoviedb.org/3/movie/${movieId}`, {
-    params: { api_key: TMDB_API_KEY, language: 'tr-TR' }
+    params: { api_key: TMDB_API_KEY, language: 'en-US' }
   });
   return res.data.title;
 }

--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -3,6 +3,7 @@ import './App.css';
 import ResultList from './components/ResultList';
 import { useSearch } from './hooks/useSearch';
 import HeroBanner from './components/HeroBanner';
+import PeriodCinema from './components/thematic_journeys';
 
 function App() {
   const {
@@ -27,6 +28,8 @@ function App() {
         title="Tüm platformlarda sinemanın en iyileri!"
         onSearch={handleHeroSearch}
       />
+
+      <PeriodCinema />
 
       {/* Yükleniyor durumu */}
       {loading && (

--- a/watchy-frontend/src/components/thematic_journeys.js
+++ b/watchy-frontend/src/components/thematic_journeys.js
@@ -2,10 +2,12 @@ import React, { useState, useEffect } from 'react';
 import './thematicjourneys.css';
 import { searchMoviesByPeriod } from '../services/api';
 
-const ThematicJourneys = () => {
+const PeriodCinema = () => {
   const [movies1980s, setMovies1980s] = useState([]);
   const [movies1990s, setMovies1990s] = useState([]);
   const [movies2000s, setMovies2000s] = useState([]);
+  const [movies2010s, setMovies2010s] = useState([]);
+  const [movies2020s, setMovies2020s] = useState([]);
   const [loading, setLoading] = useState(true);
 
   const journeys = [
@@ -35,6 +37,24 @@ const ThematicJourneys = () => {
       period: [2000, 2009],
       color: '#dc2626',
       movies: movies2000s
+    },
+    {
+      id: '2010s',
+      title: '2010s',
+      subtitle: 'Franchise era',
+      description: 'Superheroes and shared universes',
+      period: [2010, 2019],
+      color: '#9333ea',
+      movies: movies2010s
+    },
+    {
+      id: '2020s',
+      title: '2020s',
+      subtitle: 'Streaming shift',
+      description: 'Digital releases and diverse stories',
+      period: [2020, 2029],
+      color: '#f59e0b',
+      movies: movies2020s
     }
   ];
 
@@ -43,15 +63,19 @@ const ThematicJourneys = () => {
       try {
         setLoading(true);
         
-        const [data1980s, data1990s, data2000s] = await Promise.all([
+        const [data1980s, data1990s, data2000s, data2010s, data2020s] = await Promise.all([
           searchMoviesByPeriod(1980, 1989),
           searchMoviesByPeriod(1990, 1999),
-          searchMoviesByPeriod(2000, 2009)
+          searchMoviesByPeriod(2000, 2009),
+          searchMoviesByPeriod(2010, 2019),
+          searchMoviesByPeriod(2020, 2029)
         ]);
 
         setMovies1980s(data1980s.slice(0, 3));
         setMovies1990s(data1990s.slice(0, 3));
         setMovies2000s(data2000s.slice(0, 3));
+        setMovies2010s(data2010s.slice(0, 3));
+        setMovies2020s(data2020s.slice(0, 3));
       } catch (error) {
         console.error('Error fetching thematic movies:', error);
       } finally {
@@ -65,7 +89,7 @@ const ThematicJourneys = () => {
   if (loading) {
     return (
       <section className="thematic-journeys">
-        <h2 className="section-title">Thematic Journeys</h2>
+        <h2 className="section-title">Dönem Sineması</h2>
         <div className="loading-placeholder">Loading...</div>
       </section>
     );
@@ -73,7 +97,7 @@ const ThematicJourneys = () => {
 
   return (
     <section className="thematic-journeys">
-      <h2 className="section-title">Thematic Journeys</h2>
+      <h2 className="section-title">Dönem Sineması</h2>
       <div className="journeys-container">
         {journeys.map((journey) => (
           <div 
@@ -117,4 +141,5 @@ const ThematicJourneys = () => {
   );
 };
 
-export default ThematicJourneys;
+export default PeriodCinema;
+


### PR DESCRIPTION
## Summary
- display a Period Cinema section under the hero banner with decade cards for the 1980s through 2020s
- each card shows three Hollywood posters fetched by decade
- query TMDB for US productions and English metadata including watch providers

## Testing
- `npm test` (backend, expected failure: Error: no test specified)
- `CI=true npm test --silent` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68c6e1ad0d78832380fe17f58e7e6cd9