### PR TITLE
Improve TMDB authentication handling

### DIFF
--- a/watchy-backend/.env.example
+++ b/watchy-backend/.env.example
@@ -1,0 +1,5 @@
+# TMDB API anahtarınızı buraya ekleyin (v3)
+# TMDB_API_KEY=your_tmdb_v3_api_key
+
+# veya TMDB v4 read access tokenınızı girin
+# TMDB_ACCESS_TOKEN=your_tmdb_v4_access_token

--- a/watchy-backend/config/tmdb.js
+++ b/watchy-backend/config/tmdb.js
@@ -1,0 +1,61 @@
+const path = require('path');
+const dotenv = require('dotenv');
+
+const envFiles = [
+  path.resolve(__dirname, '../.env.local'),
+  path.resolve(__dirname, '../.env'),
+  path.resolve(__dirname, '../../.env')
+];
+
+for (const envPath of envFiles) {
+  dotenv.config({ path: envPath, override: false, quiet: true });
+}
+
+dotenv.config({ override: false, quiet: true });
+
+const clean = (value) => (value || '').trim();
+
+const TMDB_API_KEY = clean(process.env.TMDB_API_KEY || process.env.TMDB_V3_API_KEY);
+const TMDB_ACCESS_TOKEN = clean(process.env.TMDB_ACCESS_TOKEN || process.env.TMDB_BEARER_TOKEN);
+
+function hasTmdbCredentials() {
+  return Boolean(TMDB_API_KEY || TMDB_ACCESS_TOKEN);
+}
+
+function withTmdbAuth(config = {}) {
+  const finalConfig = {
+    ...config,
+    params: { ...(config.params || {}) },
+    headers: { ...(config.headers || {}) }
+  };
+
+  if (TMDB_API_KEY) {
+    finalConfig.params.api_key = TMDB_API_KEY;
+  }
+
+  if (TMDB_ACCESS_TOKEN) {
+    finalConfig.headers.Authorization = `Bearer ${TMDB_ACCESS_TOKEN}`;
+  }
+
+  if (Object.keys(finalConfig.params).length === 0) {
+    delete finalConfig.params;
+  }
+
+  if (Object.keys(finalConfig.headers).length === 0) {
+    delete finalConfig.headers;
+  }
+
+  return finalConfig;
+}
+
+function missingCredentialsMessage() {
+  return 'TMDB API anahtarı veya erişim token\'ı tanımlı değil. Lütfen .env dosyasında TMDB_API_KEY veya TMDB_ACCESS_TOKEN değerlerini ayarlayın.';
+}
+
+module.exports = {
+  TMDB_API_KEY,
+  TMDB_ACCESS_TOKEN,
+  hasTmdbCredentials,
+  withTmdbAuth,
+  missingCredentialsMessage
+};

--- a/watchy-backend/package-lock.json
+++ b/watchy-backend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^1.8.4",
         "cors": "^2.8.5",
+        "dotenv": "^17.2.2",
         "express": "^5.1.0"
       }
     },
@@ -183,6 +184,18 @@
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/watchy-backend/package.json
+++ b/watchy-backend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^1.8.4",
     "cors": "^2.8.5",
+    "dotenv": "^17.2.2",
     "express": "^5.1.0"
   },
   "description": ""

--- a/watchy-backend/routes/score.js
+++ b/watchy-backend/routes/score.js
@@ -2,9 +2,9 @@
 const express = require('express');
 const router = express.Router();
 const WatchyScoreTMDB = require('../utils/WatchyScoreTMDB');
+const { missingCredentialsMessage } = require('../config/tmdb');
 
-const TMDB_API_KEY = '4ff1d6d6b1541dc331260d69f3ab6921';
-const scoreCalculator = new WatchyScoreTMDB(TMDB_API_KEY);
+const scoreCalculator = new WatchyScoreTMDB();
 
 router.get('/:movieId', async (req, res) => {
   const movieId = req.params.movieId;
@@ -18,6 +18,15 @@ router.get('/:movieId', async (req, res) => {
     }
   } catch (err) {
     console.error('Watchy puanı hatası:', err.message);
+
+    if (err.message === missingCredentialsMessage()) {
+      return res.status(500).json({ error: err.message });
+    }
+
+    if (err.response?.status === 401) {
+      return res.status(401).json({ error: 'TMDB kimlik doğrulaması başarısız. Lütfen API ayarlarınızı kontrol edin.' });
+    }
+
     res.status(500).json({ error: 'Watchy puanı alınamadı.' });
   }
 });

--- a/watchy-backend/routes/search.js
+++ b/watchy-backend/routes/search.js
@@ -3,6 +3,7 @@ const express = require('express');
 const router = express.Router();
 const { searchMoviesWithCredits } = require('../services/tmdbService');
 const normalize = require('../services/normalize');
+const { missingCredentialsMessage } = require('../config/tmdb');
 
 router.get('/:query', async (req, res) => {
   const rawQuery = req.params.query;
@@ -12,7 +13,19 @@ router.get('/:query', async (req, res) => {
     const results = await searchMoviesWithCredits(query);
     res.json(results);
   } catch (err) {
-    console.error('🔴 Discover arama hatası:', err.message);
+    const status = err.response?.status || (err.message === missingCredentialsMessage() ? 500 : err.status) || 500;
+    const details = err.response?.data?.status_message || err.message;
+
+    console.error('🔴 Discover arama hatası:', details);
+
+    if (err.message === missingCredentialsMessage()) {
+      return res.status(500).json({ error: err.message });
+    }
+
+    if (status === 401) {
+      return res.status(401).json({ error: 'TMDB kimlik doğrulaması başarısız. Lütfen API anahtarınızı/tokenınızı kontrol edin.' });
+    }
+
     res.status(500).json({ error: 'Film aranırken hata oluştu.' });
   }
 });

--- a/watchy-backend/routes/searchByPeriod.js
+++ b/watchy-backend/routes/searchByPeriod.js
@@ -2,8 +2,11 @@ const express = require('express');
 const router = express.Router();
 const { getCredits } = require('../services/tmdbService');
 const axios = require('axios');
-
-const TMDB_API_KEY = '4ff1d6d6b1541dc331260d69f3ab6921';
+const {
+  withTmdbAuth,
+  hasTmdbCredentials,
+  missingCredentialsMessage
+} = require('../config/tmdb');
 
 router.get('/', async (req, res) => {
   const from = parseInt(req.query.from);
@@ -22,21 +25,28 @@ router.get('/', async (req, res) => {
   const seen = new Set();
   const results = [];
 
+  if (!hasTmdbCredentials()) {
+    console.error('🔴 TMDB kimlik bilgisi eksik:', missingCredentialsMessage());
+    return res.status(500).json({ error: missingCredentialsMessage() });
+  }
+
   try {
     for (let page = 1; page <= MAX_PAGES; page++) {
       console.log(`🌐 TMDB'den sayfa ${page} çekiliyor...`);
-      const response = await axios.get('https://api.themoviedb.org/3/discover/movie', {
-        params: {
-          api_key: TMDB_API_KEY,
-          language: 'en-US',
-          sort_by: 'popularity.desc',
-          include_adult: false,
-          page,
-          primary_release_date_gte: `${from}-01-01`,
-          primary_release_date_lte: `${to}-12-31`,
-          with_origin_country: 'US'
-        }
-      });
+      const response = await axios.get(
+        'https://api.themoviedb.org/3/discover/movie',
+        withTmdbAuth({
+          params: {
+            language: 'en-US',
+            sort_by: 'popularity.desc',
+            include_adult: false,
+            page,
+            primary_release_date_gte: `${from}-01-01`,
+            primary_release_date_lte: `${to}-12-31`,
+            with_origin_country: 'US'
+          }
+        })
+      );
 
       const movies = response.data.results || [];
       console.log(`📦 Sayfa ${page} — ${movies.length} film bulundu`);
@@ -64,7 +74,19 @@ router.get('/', async (req, res) => {
     console.log(`🎯 Toplam sonuç: ${results.length}`);
     res.json(results);
   } catch (err) {
-    console.error('🔴 Dönem araması hatası:', err.message);
+    const status = err.response?.status;
+    const details = err.response?.data?.status_message || err.message;
+
+    console.error('🔴 Dönem araması hatası:', details);
+
+    if (err.message === missingCredentialsMessage()) {
+      return res.status(500).json({ error: err.message });
+    }
+
+    if (status === 401) {
+      return res.status(401).json({ error: 'TMDB kimlik doğrulaması başarısız. Lütfen API ayarlarınızı kontrol edin.' });
+    }
+
     res.status(500).json({ error: 'Dönem araması sırasında hata oluştu.' });
   }
 });

--- a/watchy-backend/utils/WatchyScoreTMDB.js
+++ b/watchy-backend/utils/WatchyScoreTMDB.js
@@ -1,18 +1,22 @@
 
 const axios = require('axios');
+const {
+  withTmdbAuth,
+  hasTmdbCredentials,
+  missingCredentialsMessage
+} = require('../config/tmdb');
 
 class WatchyScoreTMDB {
-  constructor(apiKey) {
-    this.apiKey = apiKey;
-  }
-
   async getScore(movieId) {
+    if (!hasTmdbCredentials()) {
+      throw new Error(missingCredentialsMessage());
+    }
+
     try {
-      const res = await axios.get(`https://api.themoviedb.org/3/movie/${movieId}`, {
-        params: {
-          api_key: this.apiKey
-        }
-      });
+      const res = await axios.get(
+        `https://api.themoviedb.org/3/movie/${movieId}`,
+        withTmdbAuth()
+      );
 
       const tmdbScore = res.data.vote_average || null;
       return tmdbScore ? parseFloat(tmdbScore.toFixed(1)) : null;


### PR DESCRIPTION
## Summary
- centralize TMDB authentication config with dotenv so either a v3 API key or v4 access token can be used without hard-coding secrets
- update discovery, period/year search, and score flows to reuse the new helper, surface TMDB 401 errors, and report missing credential misconfiguration clearly
- document the required environment variables via a new .env.example and add the dotenv dependency

## Testing
- node -e "require('./services/tmdbService').searchMoviesWithCredits('matrix').then(r=>console.log('len',r.length)).catch(e=>console.error('error', e.message))"


------
https://chatgpt.com/codex/tasks/task_e_68c9b4ef3ee883239e03d9309c67fe42