### PR TITLE
Fix TMDB period search route ordering

### DIFF
--- a/watchy-backend/server.js
+++ b/watchy-backend/server.js
@@ -13,9 +13,9 @@ const PORT = process.env.PORT || 4000;
 app.use(cors());
 
 // API rotalarını tanımla
-app.use('/api/search', searchRoute);              // Örn: /api/search/:query
 app.use('/api/search/year', searchByYearRoute);   // Örn: /api/search/year/:year
-app.use('/api/search/period', searchByPeriodRoute);
+app.use('/api/search/period', searchByPeriodRoute); // Örn: /api/search/period?from=YYYY&to=YYYY
+app.use('/api/search', searchRoute);              // Örn: /api/search/:query
 app.use('/api/platforms', platformsRoute);        // Örn: /api/platforms/:movieId
 app.use('/api/watchy-score', scoreRoute);         // Örn: /api/watchy-score/:movieId
 


### PR DESCRIPTION
## Summary
- register the year and period search routes before the generic search endpoint so specific queries are not intercepted
- add an inline example for the period route for clarity

## Testing
- npm start
- curl -s "http://localhost:4000/api/search/period?from=1980&to=1989" | jq '.[0] | {movie_id, poster_path}'


------
https://chatgpt.com/codex/tasks/task_e_68c9c0c69a208323982bd5b925f24b46