### PR TITLE
Replace dotenv dependency with internal env loader

### DIFF
--- a/watchy-backend/config/tmdb.js
+++ b/watchy-backend/config/tmdb.js
@@ -1,5 +1,5 @@
+const fs = require('fs');
 const path = require('path');
-const dotenv = require('dotenv');
 
 const envFiles = [
   path.resolve(__dirname, '../.env.local'),
@@ -7,11 +7,80 @@ const envFiles = [
   path.resolve(__dirname, '../../.env')
 ];
 
-for (const envPath of envFiles) {
-  dotenv.config({ path: envPath, override: false, quiet: true });
+const loadedEnvFiles = new Set();
+
+function parseEnvLine(line) {
+  if (!line) return null;
+
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith('#')) {
+    return null;
+  }
+
+  const withoutExport = trimmed.startsWith('export ')
+    ? trimmed.slice('export '.length).trim()
+    : trimmed;
+
+  const equalsIndex = withoutExport.indexOf('=');
+  if (equalsIndex === -1) {
+    return null;
+  }
+
+  const key = withoutExport.slice(0, equalsIndex).trim();
+  if (!key) {
+    return null;
+  }
+
+  let value = withoutExport.slice(equalsIndex + 1).trim();
+
+  const isWrapped = (wrapper) => value.startsWith(wrapper) && value.endsWith(wrapper);
+
+  if (isWrapped('"') || isWrapped("'")) {
+    value = value.slice(1, -1);
+  } else {
+    const commentIndex = value.indexOf(' #');
+    if (commentIndex !== -1) {
+      value = value.slice(0, commentIndex).trim();
+    }
+  }
+
+  value = value
+    .replace(/\\n/g, '\n')
+    .replace(/\\r/g, '\r')
+    .replace(/\\t/g, '\t');
+
+  return { key, value };
 }
 
-dotenv.config({ override: false, quiet: true });
+function loadEnvFile(envPath) {
+  if (loadedEnvFiles.has(envPath) || !fs.existsSync(envPath)) {
+    return;
+  }
+
+  loadedEnvFiles.add(envPath);
+
+  try {
+    const contents = fs.readFileSync(envPath, 'utf8');
+    const lines = contents.split(/\r?\n/);
+    for (const line of lines) {
+      const parsed = parseEnvLine(line);
+      if (!parsed) continue;
+
+      const { key, value } = parsed;
+      if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
+        process.env[key] = value;
+      }
+    }
+  } catch (error) {
+    // dotenv previously operated in quiet mode, so suppress read errors.
+  }
+}
+
+for (const envPath of envFiles) {
+  loadEnvFile(envPath);
+}
+
+loadEnvFile(path.resolve(process.cwd(), '.env'));
 
 const clean = (value) => (value || '').trim();
 


### PR DESCRIPTION
## Summary
- load environment variables for TMDB configuration using an internal parser instead of the external `dotenv` package
- preserve support for multiple `.env` files without overriding existing process environment values

## Testing
- node -e "require('./config/tmdb'); console.log('config loaded');"


------
https://chatgpt.com/codex/tasks/task_e_68c9c596c90083239765c5abfc6733c0