### PR TITLE
Fix decade search to use correct TMDB date filters

### DIFF
--- a/watchy-backend/routes/searchByPeriod.js
+++ b/watchy-backend/routes/searchByPeriod.js
@@ -41,8 +41,8 @@ router.get('/', async (req, res) => {
             sort_by: 'popularity.desc',
             include_adult: false,
             page,
-            primary_release_date_gte: `${from}-01-01`,
-            primary_release_date_lte: `${to}-12-31`,
+            'primary_release_date.gte': `${from}-01-01`,
+            'primary_release_date.lte': `${to}-12-31`,
             with_origin_country: 'US'
           }
         })


### PR DESCRIPTION
## Summary
- update the decade search route to use TMDB's dotted primary_release_date filter keys so each request returns movies from the requested years

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9c7e87aa48323b0c5424f49b626e5