### PR TITLE
Add decade movie endpoint and refresh thematic cards

### DIFF
--- a/watchy-backend/routes/movies.js
+++ b/watchy-backend/routes/movies.js
@@ -1,0 +1,110 @@
+const express = require('express');
+const axios = require('axios');
+const {
+  withTmdbAuth,
+  hasTmdbCredentials,
+  missingCredentialsMessage
+} = require('../config/tmdb');
+
+const router = express.Router();
+
+const IMAGE_BASE_URL = 'https://image.tmdb.org/t/p/w342';
+const DEFAULT_LIMIT = 3;
+
+function parseYear(value) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+router.get('/decade', async (req, res) => {
+  const startParam = req.query.start;
+  const endParam = req.query.end;
+  const limitParam = req.query.limit;
+
+  const startYear = parseYear(startParam);
+  const endYear = parseYear(endParam) ?? (startYear != null ? startYear + 9 : null);
+  const parsedLimit = parseYear(limitParam) ?? DEFAULT_LIMIT;
+  const limit = Math.min(Math.max(parsedLimit, 1), 20);
+
+  if (startYear == null || endYear == null || startYear > endYear) {
+    return res.status(400).json({ error: 'Geçerli bir başlangıç ve bitiş yılı sağlamalısınız.' });
+  }
+
+  if (!hasTmdbCredentials()) {
+    return res.status(500).json({ error: missingCredentialsMessage() });
+  }
+
+  const movies = [];
+  const seen = new Set();
+  const maxPages = 5;
+
+  try {
+    for (let page = 1; page <= maxPages && movies.length < limit; page++) {
+      const response = await axios.get(
+        'https://api.themoviedb.org/3/discover/movie',
+        withTmdbAuth({
+          params: {
+            language: 'en-US',
+            sort_by: 'popularity.desc',
+            include_adult: false,
+            page,
+            'primary_release_date.gte': `${startYear}-01-01`,
+            'primary_release_date.lte': `${endYear}-12-31`,
+            with_origin_country: 'US'
+          }
+        })
+      );
+
+      const results = response.data?.results ?? [];
+      for (const film of results) {
+        if (movies.length >= limit) {
+          break;
+        }
+
+        if (!film?.id || !film?.title || seen.has(film.id)) {
+          continue;
+        }
+
+        const releaseYear = parseYear(film.release_date?.slice(0, 4));
+        if (releaseYear == null || releaseYear < startYear || releaseYear > endYear) {
+          continue;
+        }
+
+        seen.add(film.id);
+        movies.push({
+          movie_id: film.id,
+          title: film.title,
+          posterUrl: film.poster_path ? `${IMAGE_BASE_URL}${film.poster_path}` : null,
+          overview: film.overview ?? '',
+          release_year: releaseYear
+        });
+      }
+
+      const totalPages = response.data?.total_pages ?? 0;
+      if (totalPages <= page) {
+        break;
+      }
+    }
+
+    res.json(movies.slice(0, limit));
+  } catch (error) {
+    const status = error.response?.status;
+    const message = error.response?.data?.status_message || error.message;
+
+    console.error('🎬 On yıllık dilim filmleri alınamadı:', message);
+
+    if (message === missingCredentialsMessage()) {
+      return res.status(500).json({ error: message });
+    }
+
+    if (status === 401) {
+      return res
+        .status(401)
+        .json({ error: 'TMDB kimlik doğrulaması başarısız. Lütfen API ayarlarınızı kontrol edin.' });
+    }
+
+    res.status(500).json({ error: 'On yıllık döneme ait filmler alınırken hata oluştu.' });
+  }
+});
+
+module.exports = router;

--- a/watchy-backend/server.js
+++ b/watchy-backend/server.js
@@ -6,6 +6,7 @@ const searchByYearRoute = require('./routes/searchByYear');
 const searchByPeriodRoute = require('./routes/searchByPeriod');
 const platformsRoute = require('./routes/platforms');
 const scoreRoute = require('./routes/score');
+const moviesRoute = require('./routes/movies');
 
 const app = express();
 const PORT = process.env.PORT || 4000;
@@ -18,6 +19,7 @@ app.use('/api/search/period', searchByPeriodRoute); // Örn: /api/search/period?
 app.use('/api/search', searchRoute);              // Örn: /api/search/:query
 app.use('/api/platforms', platformsRoute);        // Örn: /api/platforms/:movieId
 app.use('/api/watchy-score', scoreRoute);         // Örn: /api/watchy-score/:movieId
+app.use('/api/movies', moviesRoute);              // Örn: /api/movies/decade?start=YYYY&end=YYYY
 
 // Sunucuyu başlat
 app.listen(PORT, () => {

--- a/watchy-frontend/src/components/thematic_journeys.js
+++ b/watchy-frontend/src/components/thematic_journeys.js
@@ -1,96 +1,125 @@
 import React, { useState, useEffect } from 'react';
 import './thematicjourneys.css';
-import { searchMoviesByPeriod } from '../services/api';
+import { getTopMoviesByDecade } from '../services/api';
+
+const DECADE_CARDS = [
+  {
+    id: '1950s',
+    start: 1950,
+    title: 'Naif Başlangıçlar',
+    subtitle: 'İlk melodramlar, halk hikayeleri',
+    description: 'Yeşilçam masalsı melodramlarla seyircisini buldu.',
+    color: '#1E3A8A'
+  },
+  {
+    id: '1960s',
+    start: 1960,
+    title: 'Yeşilçam Rüyası',
+    subtitle: 'Aile, aşk ve melodramın altın çağı',
+    description: 'Türk sineması romantik anlatılarıyla doruğa ulaştı.',
+    color: '#0077b6'
+  },
+  {
+    id: '1970s',
+    start: 1970,
+    title: 'Toplumcu Gerçekçilik',
+    subtitle: 'Köyden kente göç, sınıf çatışmaları',
+    description: 'Toplumsal meseleler perdeye taşındı.',
+    color: '#9b2226'
+  },
+  {
+    id: '1980s',
+    start: 1980,
+    title: 'Darbe ve Sessizlik',
+    subtitle: 'Baskı, suskunluk ve bireysel dram',
+    description: 'Politik iklim filmlere içe dönük hikâyeler kattı.',
+    color: '#003049'
+  },
+  {
+    id: '1990s',
+    start: 1990,
+    title: 'Yalnızlık ve İçe Dönüş',
+    subtitle: 'Şehirli bireylerin sancıları',
+    description: 'Bağımsız sinema bireyin yalnızlığını anlattı.',
+    color: '#386641'
+  },
+  {
+    id: '2000s',
+    start: 2000,
+    title: 'Yeni Dalga',
+    subtitle: 'Minimalizm ve estetik yoğunluk',
+    description: 'Festival dünyasında öne çıkan minimal hikâyeler.',
+    color: '#cc5803'
+  },
+  {
+    id: '2010s',
+    start: 2010,
+    title: 'Küresel Tanınırlık',
+    subtitle: "Cannes'dan Altın Portakal’a yükseliş",
+    description: 'Türkiye sineması uluslararası platformlarda ses getirdi.',
+    color: '#6a4c93'
+  },
+  {
+    id: '2020s',
+    start: 2020,
+    title: 'Dijital Geçiş',
+    subtitle: 'Festivalden platforma uzanan sinema',
+    description: 'Pandemi sonrası dijital anlatılar ve hibrit gösterimler.',
+    color: '#ff7f51'
+  }
+];
 
 const PeriodCinema = () => {
-  const [movies1980s, setMovies1980s] = useState([]);
-  const [movies1990s, setMovies1990s] = useState([]);
-  const [movies2000s, setMovies2000s] = useState([]);
-  const [movies2010s, setMovies2010s] = useState([]);
-  const [movies2020s, setMovies2020s] = useState([]);
+  const [decadeMovies, setDecadeMovies] = useState({});
   const [loading, setLoading] = useState(true);
-
-  const journeys = [
-    {
-      id: '1980s',
-      title: '1980s',
-      subtitle: 'Darbland silence',
-      description: 'Offity dramas repressed stories',
-      period: [1980, 1989],
-      color: '#2563eb',
-      movies: movies1980s
-    },
-    {
-      id: '1990s',
-      title: '1990s',
-      subtitle: 'Loneliness',
-      description: 'Introspective tales of solitude',
-      period: [1990, 1999],
-      color: '#16a34a',
-      movies: movies1990s
-    },
-    {
-      id: '2000s',
-      title: '2000s',
-      subtitle: 'New wave',
-      description: 'Aesthetic and existential films',
-      period: [2000, 2009],
-      color: '#dc2626',
-      movies: movies2000s
-    },
-    {
-      id: '2010s',
-      title: '2010s',
-      subtitle: 'Franchise era',
-      description: 'Superheroes and shared universes',
-      period: [2010, 2019],
-      color: '#9333ea',
-      movies: movies2010s
-    },
-    {
-      id: '2020s',
-      title: '2020s',
-      subtitle: 'Streaming shift',
-      description: 'Digital releases and diverse stories',
-      period: [2020, 2029],
-      color: '#f59e0b',
-      movies: movies2020s
-    }
-  ];
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    const fetchMovies = async () => {
-      try {
-        setLoading(true);
-        
-        const [data1980s, data1990s, data2000s, data2010s, data2020s] = await Promise.all([
-          searchMoviesByPeriod(1980, 1989),
-          searchMoviesByPeriod(1990, 1999),
-          searchMoviesByPeriod(2000, 2009),
-          searchMoviesByPeriod(2010, 2019),
-          searchMoviesByPeriod(2020, 2029)
-        ]);
+    let isMounted = true;
 
-        setMovies1980s(data1980s.slice(0, 3));
-        setMovies1990s(data1990s.slice(0, 3));
-        setMovies2000s(data2000s.slice(0, 3));
-        setMovies2010s(data2010s.slice(0, 3));
-        setMovies2020s(data2020s.slice(0, 3));
-      } catch (error) {
-        console.error('Error fetching thematic movies:', error);
+    const fetchMovies = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const responses = await Promise.all(
+          DECADE_CARDS.map(({ start }) => getTopMoviesByDecade(start, start + 9))
+        );
+
+        if (!isMounted) return;
+
+        const grouped = {};
+        responses.forEach((movies, index) => {
+          const { id } = DECADE_CARDS[index];
+          grouped[id] = Array.isArray(movies) ? movies.slice(0, 3) : [];
+        });
+
+        setDecadeMovies(grouped);
+      } catch (err) {
+        console.error('Error fetching thematic movies:', err);
+        if (isMounted) {
+          setError('Tematik filmler yüklenirken bir hata oluştu.');
+          setDecadeMovies({});
+        }
       } finally {
-        setLoading(false);
+        if (isMounted) {
+          setLoading(false);
+        }
       }
     };
 
     fetchMovies();
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   if (loading) {
     return (
       <section className="thematic-journeys">
         <h2 className="section-title">Dönem Sineması</h2>
-        <div className="loading-placeholder">Loading...</div>
+        <div className="loading-placeholder">Yükleniyor...</div>
       </section>
     );
   }
@@ -98,48 +127,65 @@ const PeriodCinema = () => {
   return (
     <section className="thematic-journeys">
       <h2 className="section-title">Dönem Sineması</h2>
-      <div className="journeys-container">
-        {journeys.map((journey) => (
-          <div 
-            key={journey.id} 
-            className="journey-card"
-            style={{ backgroundColor: journey.color }}
-          >
-            <div className="journey-header">
-              <h3 className="journey-title">{journey.title}</h3>
-              <h4 className="journey-subtitle">{journey.subtitle}</h4>
-              <p className="journey-description">{journey.description}</p>
-            </div>
-            
-            <div className="journey-movies">
-              {journey.movies.map((movie, index) => (
-                <div key={movie.movie_id || index} className="movie-poster">
-                  {movie.poster_path ? (
-                    <img
-                      src={`https://image.tmdb.org/t/p/w154${movie.poster_path}`}
-                      alt={movie.title}
-                      className="poster-image"
-                    />
-                  ) : (
-                    <div className="poster-placeholder">
-                      <span>🎬</span>
-                    </div>
-                  )}
+      {error ? (
+        <div className="loading-placeholder">{error}</div>
+      ) : (
+        <div className="journeys-container">
+          {DECADE_CARDS.map((journey) => {
+            const movies = decadeMovies[journey.id] || [];
+            const yearRange = `${journey.start} - ${journey.start + 9}`;
+            const posterSlots = Array.from({ length: 3 }, (_, index) => movies[index] ?? null);
+
+            return (
+              <div
+                key={journey.id}
+                className="journey-card"
+                style={{ backgroundColor: journey.color }}
+              >
+                <div className="journey-header">
+                  <span className="journey-years">{yearRange}</span>
+                  <h3 className="journey-title">{journey.title}</h3>
+                  <h4 className="journey-subtitle">{journey.subtitle}</h4>
+                  <p className="journey-description">{journey.description}</p>
                 </div>
-              ))}
-            </div>
-            
-            <div className="journey-indicators">
-              <span className="indicator active"></span>
-              <span className="indicator"></span>
-              <span className="indicator"></span>
-            </div>
-          </div>
-        ))}
-      </div>
+
+                <div className="journey-movies">
+                  {posterSlots.map((movie, index) => (
+                    <div
+                      key={movie?.movie_id || `${journey.id}-slot-${index}`}
+                      className="movie-poster"
+                    >
+                      {movie?.posterUrl ? (
+                        <img
+                          src={movie.posterUrl}
+                          alt={movie.title}
+                          className="poster-image"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className="poster-placeholder">
+                          <span>{movie ? '🎬' : 'Veri yok'}</span>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                <div className="journey-indicators">
+                  {posterSlots.map((_, indicator) => (
+                    <span
+                      key={`${journey.id}-indicator-${indicator}`}
+                      className={`indicator ${indicator === 0 ? 'active' : ''}`}
+                    ></span>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </section>
   );
 };
 
 export default PeriodCinema;
-

--- a/watchy-frontend/src/components/thematicjourneys.css
+++ b/watchy-frontend/src/components/thematicjourneys.css
@@ -31,6 +31,16 @@
   margin-bottom: 20px;
 }
 
+.journey-years {
+  display: inline-block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+  opacity: 0.85;
+}
+
 .journey-title {
   font-size: 2rem;
   font-weight: 700;
@@ -81,6 +91,8 @@
   justify-content: center;
   font-size: 1.5rem;
   background: rgba(255, 255, 255, 0.1);
+  text-align: center;
+  padding: 8px;
 }
 
 .journey-indicators {

--- a/watchy-frontend/src/services/api.js
+++ b/watchy-frontend/src/services/api.js
@@ -1,24 +1,32 @@
 export const searchMovies = async (query) => {
-    const res = await fetch(`http://localhost:4000/api/search/${encodeURIComponent(query)}`);
-    if (!res.ok) throw new Error('Film arama başarısız');
-    return await res.json();
-  };
-  
-  export const getPlatforms = async (movieId) => {
-    const res = await fetch(`http://localhost:4000/api/platforms/${movieId}`);
-    if (!res.ok) throw new Error('Platform verisi alınamadı');
-    return await res.json();
-  };
-  
-  export const getWatchyScore = async (movieId) => {
-    const res = await fetch(`http://localhost:4000/api/watchy-score/${movieId}`);
-    if (!res.ok) throw new Error('Watchy puanı alınamadı');
-    return await res.json();
-  };
-  
-  // ✅ Tematik dönemlere göre film araması
+  const res = await fetch(`http://localhost:4000/api/search/${encodeURIComponent(query)}`);
+  if (!res.ok) throw new Error('Film arama başarısız');
+  return await res.json();
+};
+
+export const getPlatforms = async (movieId) => {
+  const res = await fetch(`http://localhost:4000/api/platforms/${movieId}`);
+  if (!res.ok) throw new Error('Platform verisi alınamadı');
+  return await res.json();
+};
+
+export const getWatchyScore = async (movieId) => {
+  const res = await fetch(`http://localhost:4000/api/watchy-score/${movieId}`);
+  if (!res.ok) throw new Error('Watchy puanı alınamadı');
+  return await res.json();
+};
+
+// ✅ Tematik dönemlere göre film araması
 export const searchMoviesByPeriod = async (from, to) => {
   const res = await fetch(`http://localhost:4000/api/search/period?from=${from}&to=${to}`);
   if (!res.ok) throw new Error('Döneme göre film arama başarısız');
+  return await res.json();
+};
+
+export const getTopMoviesByDecade = async (start, end, limit = 3) => {
+  const res = await fetch(
+    `http://localhost:4000/api/movies/decade?start=${start}&end=${end}&limit=${limit}`
+  );
+  if (!res.ok) throw new Error('On yıllık döneme göre film araması başarısız');
   return await res.json();
 };


### PR DESCRIPTION
## Summary
- add a backend endpoint that returns the top three TMDB movies for a given decade
- update the PeriodCinema cards to fetch decade data and render poster slots per 10-year range
- adjust thematic journey styles to highlight year ranges and handle empty poster placeholders

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68c9cf849bac8323ac484244b296e2a6