### PR TITLE
Use configurable API base URL in frontend

### DIFF
--- a/watchy-frontend/src/hooks/useSearch.js
+++ b/watchy-frontend/src/hooks/useSearch.js
@@ -1,6 +1,6 @@
 
 import { useState } from 'react';
-import { searchMovies, getPlatforms, getWatchyScore } from '../services/api';
+import { searchMovies, getPlatforms, getWatchyScore, getApiUrl } from '../services/api';
 
 export const useSearch = () => {
   const [query, setQuery] = useState('');
@@ -49,7 +49,7 @@ export const useSearch = () => {
     setScores({});
     setLoading(true);
     try {
-      const res = await fetch(`http://localhost:4000/api/search/year/${year}`);
+      const res = await fetch(getApiUrl(`/api/search/year/${year}`));
       const data = await res.json();
       setSearchResults(data);
       for (const movie of data) {

--- a/watchy-frontend/src/services/api.js
+++ b/watchy-frontend/src/services/api.js
@@ -1,31 +1,35 @@
+export const API_BASE_URL = (process.env.REACT_APP_API_BASE_URL ?? '').replace(/\/$/, '');
+
+export const getApiUrl = (path) => `${API_BASE_URL}${path}`;
+
 export const searchMovies = async (query) => {
-  const res = await fetch(`http://localhost:4000/api/search/${encodeURIComponent(query)}`);
+  const res = await fetch(getApiUrl(`/api/search/${encodeURIComponent(query)}`));
   if (!res.ok) throw new Error('Film arama başarısız');
   return await res.json();
 };
 
 export const getPlatforms = async (movieId) => {
-  const res = await fetch(`http://localhost:4000/api/platforms/${movieId}`);
+  const res = await fetch(getApiUrl(`/api/platforms/${movieId}`));
   if (!res.ok) throw new Error('Platform verisi alınamadı');
   return await res.json();
 };
 
 export const getWatchyScore = async (movieId) => {
-  const res = await fetch(`http://localhost:4000/api/watchy-score/${movieId}`);
+  const res = await fetch(getApiUrl(`/api/watchy-score/${movieId}`));
   if (!res.ok) throw new Error('Watchy puanı alınamadı');
   return await res.json();
 };
 
 // ✅ Tematik dönemlere göre film araması
 export const searchMoviesByPeriod = async (from, to) => {
-  const res = await fetch(`http://localhost:4000/api/search/period?from=${from}&to=${to}`);
+  const res = await fetch(getApiUrl(`/api/search/period?from=${from}&to=${to}`));
   if (!res.ok) throw new Error('Döneme göre film arama başarısız');
   return await res.json();
 };
 
 export const getTopMoviesByDecade = async (start, end, limit = 3) => {
   const res = await fetch(
-    `http://localhost:4000/api/movies/decade?start=${start}&end=${end}&limit=${limit}`
+    getApiUrl(`/api/movies/decade?start=${start}&end=${end}&limit=${limit}`)
   );
   if (!res.ok) throw new Error('On yıllık döneme göre film araması başarısız');
   return await res.json();


### PR DESCRIPTION
## Summary
- add a shared API base URL helper so all service fetches work with CRA proxy or a configured origin
- update the year-based search fetch to reuse the helper instead of hardcoding localhost

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68c9d44e2cf48323b07963b0099d7410