### PR TITLE
Ensure fallback movies are used when TMDB decade fetch fails

### DIFF
--- a/watchy-backend/routes/movies.js
+++ b/watchy-backend/routes/movies.js
@@ -98,13 +98,19 @@ router.get('/decade', async (req, res) => {
 
     console.error('🎬 On yıllık dilim filmleri alınamadı:', message);
 
-    if (message === missingCredentialsMessage()) {
-      const fallbackMovies = getFallbackMovies(startYear, endYear, limit);
-      if (fallbackMovies.length > 0) {
-        console.warn('⚠️  TMDB kimlik bilgileri eksik. Yerel dönem filmleri kullanılıyor.');
-        return res.json(fallbackMovies);
-      }
+    const fallbackMovies = getFallbackMovies(startYear, endYear, limit);
+    if (fallbackMovies.length > 0) {
+      const reason =
+        message === missingCredentialsMessage()
+          ? 'TMDB kimlik bilgileri eksik.'
+          : status === 401
+          ? 'TMDB kimlik doğrulaması başarısız.'
+          : 'TMDB isteği başarısız oldu.';
+      console.warn(`⚠️  ${reason} Yerel dönem filmleri kullanılıyor.`);
+      return res.json(fallbackMovies);
+    }
 
+    if (message === missingCredentialsMessage()) {
       return res.status(500).json({ error: message });
     }
 
@@ -112,12 +118,6 @@ router.get('/decade', async (req, res) => {
       return res
         .status(401)
         .json({ error: 'TMDB kimlik doğrulaması başarısız. Lütfen API ayarlarınızı kontrol edin.' });
-    }
-
-    const fallbackMovies = getFallbackMovies(startYear, endYear, limit);
-    if (fallbackMovies.length > 0) {
-      console.warn('⚠️  TMDB isteği başarısız oldu. Yerel dönem filmleri kullanılıyor.');
-      return res.json(fallbackMovies);
     }
 
     res.status(500).json({ error: 'On yıllık döneme ait filmler alınırken hata oluştu.' });


### PR DESCRIPTION
## Summary
- ensure fallback decade movies are returned whenever TMDB requests fail, including authentication failures
- log the specific reason when falling back to local data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cbc382eb108323a44966f159232d67