### PR TITLE
Fix API default base URL for production

### DIFF
--- a/watchy-frontend/src/services/api.js
+++ b/watchy-frontend/src/services/api.js
@@ -1,4 +1,16 @@
-const DEFAULT_API_BASE = 'http://localhost:4000/api';
+const getDefaultApiBase = () => {
+  if (process.env.NODE_ENV === 'development') {
+    return 'http://localhost:4000/api';
+  }
+
+  if (typeof window !== 'undefined' && window.location?.origin) {
+    return `${window.location.origin}/api`;
+  }
+
+  return '/api';
+};
+
+const DEFAULT_API_BASE = getDefaultApiBase();
 
 const sanitizeBaseUrl = (url) => {
   if (!url) return DEFAULT_API_BASE;


### PR DESCRIPTION
## Summary
- update the frontend API client to default to the deployment origin in production while keeping the localhost target for development

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cda27d0a7483239a48022a3c759f80