### PR TITLE
Fix missing hook imports in ThematicJourneys

### DIFF
--- a/watchy-frontend/src/components/thematicjourneys.js
+++ b/watchy-frontend/src/components/thematicjourneys.js
@@ -1,4 +1,5 @@
 
+import { useEffect, useMemo, useState } from 'react';
 import './thematicjourneys.css';
 import { searchMoviesByPeriod } from '../services/api';
 


### PR DESCRIPTION
## Summary
- import React hooks for ThematicJourneys component to resolve runtime ReferenceError

## Testing
- npm run build *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce7f85403c83239fd3ccb513054f78