### PR TITLE
Filter results by platform availability

### DIFF
--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -11,6 +11,7 @@ function App() {
     platforms,
     scores,
     loading,
+    hasCompletedSearch,
     handleSearch
   } = useSearch();
 
@@ -46,6 +47,7 @@ function App() {
           searchResults={searchResults}
           platforms={platforms}
           scores={scores}
+          hasCompletedSearch={hasCompletedSearch}
         />
       </div>
     </div>

--- a/watchy-frontend/src/components/MovieCard.js
+++ b/watchy-frontend/src/components/MovieCard.js
@@ -2,21 +2,34 @@
 import React from 'react';
 
 function MovieCard({ movie, platforms }) {
+  const uniquePlatforms = Array.isArray(platforms)
+    ? platforms.filter((platform, index, list) => {
+        if (platform?.provider_id) {
+          return (
+            list.findIndex((item) => item?.provider_id === platform.provider_id) === index
+          );
+        }
+
+        return (
+          index ===
+          list.findIndex((item) => item?.provider_name === platform?.provider_name)
+        );
+      })
+    : [];
+
   return (
     <div
       className="movie-tile"
       style={{
-        width: '200px',
+        width: '220px',
         backgroundColor: '#111',
         border: '1px solid #333',
-        borderRadius: '6px',
-        padding: '10px',
+        borderRadius: '10px',
+        padding: '12px',
         color: 'white',
         display: 'flex',
         flexDirection: 'column',
-        alignItems: 'center',
-        fontSize: '12px',
-        gap: '8px'
+        gap: '10px'
       }}
     >
       <div
@@ -24,90 +37,83 @@ function MovieCard({ movie, platforms }) {
           width: '100%',
           display: 'flex',
           alignItems: 'flex-start',
-          gap: '8px'
+          gap: '12px'
         }}
       >
-        <div style={{ width: '70px', flexShrink: 0 }}>
+        <div style={{ width: '80px', flexShrink: 0 }}>
           {movie.poster_path ? (
             <img
               src={`https://image.tmdb.org/t/p/w154${movie.poster_path}`}
               alt={movie.title}
-              style={{ borderRadius: '4px', width: '100%', objectFit: 'cover' }}
+              style={{
+                borderRadius: '6px',
+                width: '100%',
+                objectFit: 'cover',
+                boxShadow: '0 4px 12px rgba(0, 0, 0, 0.35)'
+              }}
             />
           ) : (
             <div
               style={{
                 width: '100%',
-                height: '105px',
+                height: '115px',
                 background: '#333',
-                borderRadius: '4px',
+                borderRadius: '6px',
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                fontSize: '24px'
+                fontSize: '26px'
               }}
             >
               🎬
             </div>
           )}
         </div>
-        {platforms && platforms.length > 0 ? (
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '6px',
-              flex: 1
-            }}
-          >
-            {platforms.map((p, i) => (
-              <div
-                key={i}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '6px',
-                  backgroundColor: '#1c1c1c',
-                  borderRadius: '4px',
-                  padding: '4px 6px'
-                }}
-              >
-                <img
-                  src={
-                    p.logo_path === '/yt'
-                      ? 'https://upload.wikimedia.org/wikipedia/commons/0/09/YouTube_full-color_icon_(2017).svg'
-                      : `https://image.tmdb.org/t/p/w92${p.logo_path}`
-                  }
-                  alt={p.provider_name}
-                  title={p.provider_name}
-                  style={{ height: '16px' }}
-                />
-                <span style={{ fontSize: '11px', color: '#f1f1f1' }}>{p.provider_name}</span>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              flex: 1,
-              fontSize: '11px',
-              color: '#999',
-              backgroundColor: '#1a1a1a',
-              borderRadius: '4px',
-              padding: '6px'
-            }}
-          >
-            Platform bilgisi bulunamadı
-          </div>
-        )}
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '8px',
+            rowGap: '6px',
+            alignItems: 'center'
+          }}
+        >
+          {uniquePlatforms.map((platform) => (
+            <div
+              key={platform?.provider_id || platform?.provider_name}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '6px',
+                backgroundColor: '#1c1c1c',
+                borderRadius: '20px',
+                padding: '4px 8px',
+                boxShadow: '0 2px 6px rgba(0, 0, 0, 0.4)'
+              }}
+            >
+              <img
+                src={
+                  platform?.logo_path === '/yt'
+                    ? 'https://upload.wikimedia.org/wikipedia/commons/0/09/YouTube_full-color_icon_(2017).svg'
+                    : `https://image.tmdb.org/t/p/w92${platform?.logo_path}`
+                }
+                alt={platform?.provider_name}
+                title={platform?.provider_name}
+                style={{ height: '18px', width: 'auto' }}
+              />
+              <span style={{ fontSize: '11px', color: '#f1f1f1' }}>
+                {platform?.provider_name}
+              </span>
+            </div>
+          ))}
+        </div>
       </div>
       <div style={{ textAlign: 'center' }}>
-        <strong style={{ display: 'block', marginBottom: '2px' }}>{movie.title}</strong>
-        <div style={{ fontSize: '11px' }}>{movie.release_date?.slice(0, 4)}</div>
-        <div style={{ fontSize: '10px', color: '#aaa' }}>{movie.director}</div>
+        <strong style={{ display: 'block', marginBottom: '4px', fontSize: '13px' }}>
+          {movie.title}
+        </strong>
+        <div style={{ fontSize: '11px', color: '#ddd' }}>{movie.release_date?.slice(0, 4)}</div>
+        <div style={{ fontSize: '10px', color: '#aaa', marginTop: '2px' }}>{movie.director}</div>
       </div>
     </div>
   );

--- a/watchy-frontend/src/components/ResultList.js
+++ b/watchy-frontend/src/components/ResultList.js
@@ -2,15 +2,43 @@
 import React from 'react';
 import MovieCard from './MovieCard';
 
-function ResultList({ searchResults, platforms }) {
+function ResultList({ searchResults, platforms, hasCompletedSearch }) {
+  const visibleMovies = Array.isArray(searchResults)
+    ? searchResults.filter((movie) => {
+        const platformInfo = platforms[movie.movie_id]?.platforms;
+        return Array.isArray(platformInfo) && platformInfo.length > 0;
+      })
+    : [];
+
+  if (!visibleMovies.length) {
+    if (!hasCompletedSearch) {
+      return null;
+    }
+
+    return (
+      <div
+        style={{
+          marginTop: '40px',
+          textAlign: 'center',
+          color: '#9ca3af',
+          fontSize: '14px'
+        }}
+      >
+        Aradığınız kriterlerde platformlarda erişilebilir film bulunamadı.
+      </div>
+    );
+  }
+
   return (
-    <div style={{
-      display: 'grid',
-      gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
-      gap: '14px',
-      marginTop: '20px'
-    }}>
-      {searchResults.map((movie) => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+        gap: '18px',
+        marginTop: '20px'
+      }}
+    >
+      {visibleMovies.map((movie) => (
         <MovieCard
           key={movie.movie_id}
           movie={movie}


### PR DESCRIPTION
## Summary
- fetch platform metadata alongside search results and filter out films without an available platform
- refresh movie card layout to highlight streaming logos beside the poster and deduplicate providers
- show an informative empty state only after a search completes when no streamable titles remain

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68ce8d82ee1083239a8ef90dd5daa0ff