### PR TITLE
Restrict watch providers to Turkish availability

### DIFF
--- a/watchy-backend/services/tmdbService.js
+++ b/watchy-backend/services/tmdbService.js
@@ -86,7 +86,7 @@ async function searchMoviesWithCredits(query) {
   return filtered;
 }
 
-const REGION_PRIORITY = ['TR', 'US', 'GB', 'CA'];
+const REGION_TURKEY = 'TR';
 const CATEGORY_PRIORITY = ['flatrate', 'free', 'ads', 'rent', 'buy'];
 
 async function getWatchProviders(movieId) {
@@ -97,59 +97,56 @@ async function getWatchProviders(movieId) {
   );
 
   const results = res.data?.results || {};
-
-  for (const regionCode of REGION_PRIORITY) {
-    const regionInfo = results[regionCode];
-    if (!regionInfo) {
-      continue;
-    }
-
-    const providerMap = new Map();
-
-    CATEGORY_PRIORITY.forEach((category) => {
-      const providers = Array.isArray(regionInfo[category])
-        ? regionInfo[category]
-        : [];
-
-      providers.forEach((provider) => {
-        const key = provider?.provider_id || provider?.provider_name;
-        if (!key) return;
-
-        const existing = providerMap.get(key);
-        if (
-          !existing ||
-          CATEGORY_PRIORITY.indexOf(category) <
-            CATEGORY_PRIORITY.indexOf(existing.availability)
-        ) {
-          providerMap.set(key, {
-            ...provider,
-            availability: category,
-            region: regionCode
-          });
-        }
-      });
-    });
-
-    if (providerMap.size) {
-      const platforms = Array.from(providerMap.values()).sort((a, b) => {
-        const aPriority = a.display_priority ?? Number.MAX_SAFE_INTEGER;
-        const bPriority = b.display_priority ?? Number.MAX_SAFE_INTEGER;
-
-        if (aPriority !== bPriority) {
-          return aPriority - bPriority;
-        }
-
-        return a.provider_name.localeCompare(b.provider_name);
-      });
-
-      return {
-        platforms,
-        link: regionInfo.link || ''
-      };
-    }
+  const regionInfo = results[REGION_TURKEY];
+  if (!regionInfo) {
+    return { platforms: [], link: '' };
   }
 
-  return { platforms: [], link: '' };
+  const providerMap = new Map();
+
+  CATEGORY_PRIORITY.forEach((category) => {
+    const providers = Array.isArray(regionInfo[category])
+      ? regionInfo[category]
+      : [];
+
+    providers.forEach((provider) => {
+      const key = provider?.provider_id || provider?.provider_name;
+      if (!key) return;
+
+      const existing = providerMap.get(key);
+      if (
+        !existing ||
+        CATEGORY_PRIORITY.indexOf(category) <
+          CATEGORY_PRIORITY.indexOf(existing.availability)
+      ) {
+        providerMap.set(key, {
+          ...provider,
+          availability: category,
+          region: REGION_TURKEY
+        });
+      }
+    });
+  });
+
+  if (!providerMap.size) {
+    return { platforms: [], link: '' };
+  }
+
+  const platforms = Array.from(providerMap.values()).sort((a, b) => {
+    const aPriority = a.display_priority ?? Number.MAX_SAFE_INTEGER;
+    const bPriority = b.display_priority ?? Number.MAX_SAFE_INTEGER;
+
+    if (aPriority !== bPriority) {
+      return aPriority - bPriority;
+    }
+
+    return a.provider_name.localeCompare(b.provider_name);
+  });
+
+  return {
+    platforms,
+    link: regionInfo.link || ''
+  };
 }
 
 async function getMovieTitle(movieId) {


### PR DESCRIPTION
## Summary
- update TMDB watch provider lookup to require Turkish availability
- return no platforms when a movie lacks Turkish providers so the frontend filters it out

## Testing
- `npm --prefix watchy-backend test`

------
https://chatgpt.com/codex/tasks/task_e_68cef75f86c4832397893d1e76c0f70b