### PR TITLE
Filter decade search results by streaming availability

### DIFF
--- a/watchy-backend/routes/searchByPeriod.js
+++ b/watchy-backend/routes/searchByPeriod.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { getCredits } = require('../services/tmdbService');
+const { getCredits, getWatchProviders } = require('../services/tmdbService');
 const axios = require('axios');
 const {
   withTmdbAuth,
@@ -21,9 +21,12 @@ router.get('/', async (req, res) => {
 
   console.log(`🔍 Film aranıyor: ${from} - ${to} arası`);
 
-  const MAX_PAGES = 3;
+  const MAX_PAGES = 10;
+  const MAX_RESULTS = 30;
+  const MIN_VOTE_COUNT = 100;
   const seen = new Set();
   const results = [];
+  const providerCache = new Map();
 
   if (!hasTmdbCredentials()) {
     console.error('🔴 TMDB kimlik bilgisi eksik:', missingCredentialsMessage());
@@ -31,19 +34,20 @@ router.get('/', async (req, res) => {
   }
 
   try {
-    for (let page = 1; page <= MAX_PAGES; page++) {
+    for (let page = 1; page <= MAX_PAGES && results.length < MAX_RESULTS; page++) {
       console.log(`🌐 TMDB'den sayfa ${page} çekiliyor...`);
       const response = await axios.get(
         'https://api.themoviedb.org/3/discover/movie',
         withTmdbAuth({
           params: {
             language: 'en-US',
-            sort_by: 'popularity.desc',
+            sort_by: 'vote_average.desc',
             include_adult: false,
             page,
             'primary_release_date.gte': `${from}-01-01`,
             'primary_release_date.lte': `${to}-12-31`,
-            with_origin_country: 'US'
+            with_origin_country: 'US',
+            'vote_count.gte': MIN_VOTE_COUNT
           }
         })
       );
@@ -57,28 +61,63 @@ router.get('/', async (req, res) => {
           continue;
         }
 
-        if (!seen.has(film.id)) {
-          seen.add(film.id);
-          const { director, cast } = await getCredits(film.id);
-          results.push({
-            movie_id: film.id,
-            title: film.title,
-            poster_path: film.poster_path,
-            overview: film.overview,
-            release_date: film.release_date,
-            director,
-            cast
-          });
+        if (seen.has(film.id)) {
+          continue;
+        }
+
+        if (Number(film.vote_count ?? 0) < MIN_VOTE_COUNT) {
+          continue;
+        }
+
+        let providers = providerCache.get(film.id);
+
+        if (!providers) {
+          try {
+            providers = await getWatchProviders(film.id);
+            providerCache.set(film.id, providers);
+          } catch (error) {
+            console.error(`📺 Platform bilgisi alınamadı (${film.id}):`, error?.message || error);
+            providerCache.set(film.id, { platforms: [], link: '' });
+            continue;
+          }
+        }
+
+        const platforms = Array.isArray(providers?.platforms) ? providers.platforms : [];
+        if (platforms.length === 0) {
+          continue;
+        }
+
+        seen.add(film.id);
+
+        const { director, cast } = await getCredits(film.id);
+        results.push({
+          movie_id: film.id,
+          title: film.title,
+          poster_path: film.poster_path,
+          overview: film.overview,
+          release_date: film.release_date,
+          director,
+          cast,
+          vote_average: film.vote_average,
+          vote_count: film.vote_count,
+          platforms,
+          watch_link: providers?.link || ''
+        });
+
+        if (results.length >= MAX_RESULTS) {
+          break;
         }
       }
 
       if (response.data.total_pages <= page) break;
     }
 
-    const filteredResults = results.filter((result) => {
-      const releaseYear = Number(result.release_date?.slice(0, 4));
-      return Number.isFinite(releaseYear) && releaseYear >= from && releaseYear <= to;
-    });
+    const filteredResults = results
+      .filter((result) => {
+        const releaseYear = Number(result.release_date?.slice(0, 4));
+        return Number.isFinite(releaseYear) && releaseYear >= from && releaseYear <= to;
+      })
+      .slice(0, MAX_RESULTS);
 
     console.log(`🎯 Toplam sonuç: ${filteredResults.length}`);
     res.json(filteredResults);


### PR DESCRIPTION
## Summary
- update the period search endpoint to rank by TMDB vote average rather than popularity
- restrict the response to the first 30 titles per decade that have sufficient votes and are available on streaming platforms in Turkey
- attach platform details and rating metadata to each movie in the response for reuse on the frontend

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cefaba97748323b9db1f7a95ff7ab9