### PR TITLE
Make platform badges link to movie pages

### DIFF
--- a/watchy-frontend/src/components/MovieCard.js
+++ b/watchy-frontend/src/components/MovieCard.js
@@ -1,7 +1,7 @@
 
 import React from 'react';
 
-function MovieCard({ movie, platforms }) {
+function MovieCard({ movie, platforms, platformLink }) {
   const uniquePlatforms = Array.isArray(platforms)
     ? platforms.filter((platform, index, list) => {
         if (platform?.provider_id) {
@@ -78,34 +78,62 @@ function MovieCard({ movie, platforms }) {
             alignItems: 'center'
           }}
         >
-          {uniquePlatforms.map((platform) => (
-            <div
-              key={platform?.provider_id || platform?.provider_name}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: '6px',
-                backgroundColor: '#1c1c1c',
-                borderRadius: '20px',
-                padding: '4px 8px',
-                boxShadow: '0 2px 6px rgba(0, 0, 0, 0.4)'
-              }}
-            >
-              <img
-                src={
-                  platform?.logo_path === '/yt'
-                    ? 'https://upload.wikimedia.org/wikipedia/commons/0/09/YouTube_full-color_icon_(2017).svg'
-                    : `https://image.tmdb.org/t/p/w92${platform?.logo_path}`
-                }
-                alt={platform?.provider_name}
-                title={platform?.provider_name}
-                style={{ height: '18px', width: 'auto' }}
-              />
-              <span style={{ fontSize: '11px', color: '#f1f1f1' }}>
-                {platform?.provider_name}
-              </span>
-            </div>
-          ))}
+          {uniquePlatforms.map((platform) => {
+            const badgeStyle = {
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+              backgroundColor: '#1c1c1c',
+              borderRadius: '20px',
+              padding: '4px 8px',
+              boxShadow: '0 2px 6px rgba(0, 0, 0, 0.4)'
+            };
+
+            const content = (
+              <>
+                <img
+                  src={
+                    platform?.logo_path === '/yt'
+                      ? 'https://upload.wikimedia.org/wikipedia/commons/0/09/YouTube_full-color_icon_(2017).svg'
+                      : `https://image.tmdb.org/t/p/w92${platform?.logo_path}`
+                  }
+                  alt={platform?.provider_name}
+                  title={platform?.provider_name}
+                  style={{ height: '18px', width: 'auto' }}
+                />
+                <span style={{ fontSize: '11px', color: '#f1f1f1' }}>
+                  {platform?.provider_name}
+                </span>
+              </>
+            );
+
+            if (platformLink) {
+              return (
+                <a
+                  key={platform?.provider_id || platform?.provider_name}
+                  href={platformLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    ...badgeStyle,
+                    textDecoration: 'none',
+                    color: 'inherit'
+                  }}
+                >
+                  {content}
+                </a>
+              );
+            }
+
+            return (
+              <div
+                key={platform?.provider_id || platform?.provider_name}
+                style={badgeStyle}
+              >
+                {content}
+              </div>
+            );
+          })}
         </div>
       </div>
       <div style={{ textAlign: 'center' }}>

--- a/watchy-frontend/src/components/ResultList.js
+++ b/watchy-frontend/src/components/ResultList.js
@@ -43,6 +43,7 @@ function ResultList({ searchResults, platforms, hasCompletedSearch }) {
           key={movie.movie_id}
           movie={movie}
           platforms={platforms[movie.movie_id]?.platforms || []}
+          platformLink={platforms[movie.movie_id]?.link || ''}
         />
       ))}
     </div>

--- a/watchy-frontend/src/components/thematicjourneys.js
+++ b/watchy-frontend/src/components/thematicjourneys.js
@@ -146,7 +146,8 @@ const ThematicJourneys = () => {
                 return {
                   ...movie,
                   id: movieId,
-                  platforms: platformUpdates[movieId].platforms
+                  platforms: platformUpdates[movieId].platforms,
+                  link: platformUpdates[movieId].link
                 };
               })
             );
@@ -235,7 +236,8 @@ const ThematicJourneys = () => {
             director: movie.director || null,
             cast: Array.isArray(movie.cast) ? movie.cast.slice(0, 3) : [],
             releaseYear: movie.release_date ? movie.release_date.slice(0, 4) : null,
-            platforms: platformUpdates[movieId].platforms
+            platforms: platformUpdates[movieId].platforms,
+            link: platformUpdates[movieId].link
           };
         })
       );
@@ -305,6 +307,8 @@ const ThematicJourneys = () => {
               <div className="journey-movies">
                 {journey.movies.map((movie, index) => {
                   const uniquePlatforms = dedupePlatforms(movie.platforms);
+                  const movieId = movie.id || movie.movie_id;
+                  const movieLink = movie.link || (movieId ? platformsByMovieId[movieId]?.link : '');
 
                   return (
                     <div key={movie.id || movie.movie_id || index} className="movie-poster">
@@ -321,23 +325,41 @@ const ThematicJourneys = () => {
                       )}
 
                       <div className="movie-platforms">
-                        {uniquePlatforms.map((platform) => (
-                          <div
-                            key={platform?.provider_id || platform?.provider_name}
-                            className="platform-badge"
-                          >
-                            <img
-                              src={
-                                platform?.logo_path === '/yt'
-                                  ? 'https://upload.wikimedia.org/wikipedia/commons/0/09/YouTube_full-color_icon_(2017).svg'
-                                  : `https://image.tmdb.org/t/p/w92${platform?.logo_path}`
-                              }
-                              alt={platform?.provider_name}
-                              title={platform?.provider_name}
-                            />
-                            <span>{platform?.provider_name}</span>
-                          </div>
-                        ))}
+                        {uniquePlatforms.map((platform) => {
+                          const badgeContent = (
+                            <>
+                              <img
+                                src={
+                                  platform?.logo_path === '/yt'
+                                    ? 'https://upload.wikimedia.org/wikipedia/commons/0/09/YouTube_full-color_icon_(2017).svg'
+                                    : `https://image.tmdb.org/t/p/w92${platform?.logo_path}`
+                                }
+                                alt={platform?.provider_name}
+                                title={platform?.provider_name}
+                              />
+                              <span>{platform?.provider_name}</span>
+                            </>
+                          );
+
+                          return movieLink ? (
+                            <a
+                              key={platform?.provider_id || platform?.provider_name}
+                              className="platform-badge"
+                              href={movieLink}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {badgeContent}
+                            </a>
+                          ) : (
+                            <div
+                              key={platform?.provider_id || platform?.provider_name}
+                              className="platform-badge"
+                            >
+                              {badgeContent}
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                   );
@@ -389,6 +411,7 @@ const ThematicJourneys = () => {
             <div className="detail-movie-list">
               {(detailMovies[activeJourney.id] || []).map((movie) => {
                 const uniquePlatforms = dedupePlatforms(movie.platforms);
+                const movieLink = movie.link || (movie.id ? platformsByMovieId[movie.id]?.link : '');
 
                 return (
                   <article key={movie.id} className="detail-movie-card">
@@ -416,23 +439,41 @@ const ThematicJourneys = () => {
                       </p>
                     )}
                     <div className="detail-movie-platforms">
-                      {uniquePlatforms.map((platform) => (
-                        <div
-                          key={platform?.provider_id || platform?.provider_name}
-                          className="platform-badge"
-                        >
-                          <img
-                            src={
-                              platform?.logo_path === '/yt'
-                                ? 'https://upload.wikimedia.org/wikipedia/commons/0/09/YouTube_full-color_icon_(2017).svg'
-                                : `https://image.tmdb.org/t/p/w92${platform?.logo_path}`
-                            }
-                            alt={platform?.provider_name}
-                            title={platform?.provider_name}
-                          />
-                          <span>{platform?.provider_name}</span>
-                        </div>
-                      ))}
+                      {uniquePlatforms.map((platform) => {
+                        const badgeContent = (
+                          <>
+                            <img
+                              src={
+                                platform?.logo_path === '/yt'
+                                  ? 'https://upload.wikimedia.org/wikipedia/commons/0/09/YouTube_full-color_icon_(2017).svg'
+                                  : `https://image.tmdb.org/t/p/w92${platform?.logo_path}`
+                              }
+                              alt={platform?.provider_name}
+                              title={platform?.provider_name}
+                            />
+                            <span>{platform?.provider_name}</span>
+                          </>
+                        );
+
+                        return movieLink ? (
+                          <a
+                            key={platform?.provider_id || platform?.provider_name}
+                            className="platform-badge"
+                            href={movieLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            {badgeContent}
+                          </a>
+                        ) : (
+                          <div
+                            key={platform?.provider_id || platform?.provider_name}
+                            className="platform-badge"
+                          >
+                            {badgeContent}
+                          </div>
+                        );
+                      })}
                     </div>
                   </div>
                 </article>


### PR DESCRIPTION
## Summary
- pass platform-specific streaming links from search results into the movie cards
- make platform badges clickable in movie cards and thematic journey sections so they open the film on the provider in a new tab
- persist platform links when fetching decade highlights and detailed journey data so anchor targets stay available

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cefeca654483239455d145d5032ccc