### PR TITLE
Add direct streaming links for platforms

### DIFF
--- a/watchy-backend/services/tmdbService.js
+++ b/watchy-backend/services/tmdbService.js
@@ -89,6 +89,107 @@ async function searchMoviesWithCredits(query) {
 const REGION_TURKEY = 'TR';
 const CATEGORY_PRIORITY = ['flatrate', 'free', 'ads', 'rent', 'buy'];
 
+const WATCH_LINK_CACHE = new Map();
+
+function getCacheKey(movieId, link) {
+  return `${movieId}::${link || ''}`;
+}
+
+function decodeJustWatchContext(encoded) {
+  try {
+    const jsonText = Buffer.from(encoded, 'base64').toString('utf-8');
+    const parsed = JSON.parse(jsonText);
+    return parsed;
+  } catch (error) {
+    return null;
+  }
+}
+
+function extractProviderLinksFromHtml(html) {
+  const providerLinks = new Map();
+  if (typeof html !== 'string' || html.length === 0) {
+    return providerLinks;
+  }
+
+  const linkRegex = /https:\/\/click\.justwatch\.com\/a\?[^"'>]+/g;
+  const matches = html.matchAll(linkRegex);
+
+  for (const match of matches) {
+    const href = match[0];
+
+    try {
+      const url = new URL(href);
+      const context = url.searchParams.get('cx');
+      const redirect = url.searchParams.get('r');
+
+      if (!context || !redirect) {
+        continue;
+      }
+
+      const decoded = decodeJustWatchContext(context);
+      if (!decoded) {
+        continue;
+      }
+
+      const dataArray = Array.isArray(decoded.data) ? decoded.data : [];
+
+      dataArray.forEach((entry) => {
+        const details = entry?.data || {};
+        const providerId =
+          details.providerId ?? details.provider_id ?? details.providerid;
+        const providerName =
+          details.provider ?? details.provider_name ?? details.providerName;
+
+        if (!providerId || providerLinks.has(providerId)) {
+          return;
+        }
+
+        providerLinks.set(providerId, {
+          url: redirect,
+          providerName: providerName || null
+        });
+      });
+    } catch (error) {
+      continue;
+    }
+  }
+
+  return providerLinks;
+}
+
+async function fetchWatchLinks(movieId, link) {
+  if (!link) {
+    return new Map();
+  }
+
+  const cacheKey = getCacheKey(movieId, link);
+  if (WATCH_LINK_CACHE.has(cacheKey)) {
+    return WATCH_LINK_CACHE.get(cacheKey);
+  }
+
+  try {
+    const response = await axios.get(link, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36',
+        'Accept-Language': 'tr-TR,tr;q=0.9,en-US;q=0.8,en;q=0.7'
+      },
+      timeout: 10000
+    });
+
+    const providerLinks = extractProviderLinksFromHtml(response.data);
+    WATCH_LINK_CACHE.set(cacheKey, providerLinks);
+    return providerLinks;
+  } catch (error) {
+    console.error(
+      `🎬 Doğrudan platform linkleri alınamadı (ID: ${movieId}):`,
+      error.message
+    );
+    WATCH_LINK_CACHE.set(cacheKey, new Map());
+    return new Map();
+  }
+}
+
 async function getWatchProviders(movieId) {
   ensureCredentials();
   const res = await axios.get(
@@ -143,8 +244,23 @@ async function getWatchProviders(movieId) {
     return a.provider_name.localeCompare(b.provider_name);
   });
 
+  const directLinks = await fetchWatchLinks(movieId, regionInfo.link || '');
+
+  const platformsWithLinks = platforms.map((platform) => {
+    const providerId = platform?.provider_id || platform?.providerId;
+    const matchingLink = providerId
+      ? directLinks.get(providerId) || directLinks.get(String(providerId))
+      : null;
+
+    return {
+      ...platform,
+      direct_link: matchingLink?.url || '',
+      direct_link_provider_name: matchingLink?.providerName || null
+    };
+  });
+
   return {
-    platforms,
+    platforms: platformsWithLinks,
     link: regionInfo.link || ''
   };
 }

--- a/watchy-frontend/src/components/MovieCard.js
+++ b/watchy-frontend/src/components/MovieCard.js
@@ -107,11 +107,14 @@ function MovieCard({ movie, platforms, platformLink }) {
               </>
             );
 
-            if (platformLink) {
+            const linkForPlatform =
+              platform?.direct_link || platform?.external_link || platformLink;
+
+            if (linkForPlatform) {
               return (
                 <a
                   key={platform?.provider_id || platform?.provider_name}
-                  href={platformLink}
+                  href={linkForPlatform}
                   target="_blank"
                   rel="noopener noreferrer"
                   style={{

--- a/watchy-frontend/src/components/thematicjourneys.js
+++ b/watchy-frontend/src/components/thematicjourneys.js
@@ -326,6 +326,10 @@ const ThematicJourneys = () => {
 
                       <div className="movie-platforms">
                         {uniquePlatforms.map((platform) => {
+                          const linkForPlatform =
+                            platform?.direct_link ||
+                            platform?.external_link ||
+                            movieLink;
                           const badgeContent = (
                             <>
                               <img
@@ -341,11 +345,11 @@ const ThematicJourneys = () => {
                             </>
                           );
 
-                          return movieLink ? (
+                          return linkForPlatform ? (
                             <a
                               key={platform?.provider_id || platform?.provider_name}
                               className="platform-badge"
-                              href={movieLink}
+                              href={linkForPlatform}
                               target="_blank"
                               rel="noopener noreferrer"
                             >
@@ -440,6 +444,10 @@ const ThematicJourneys = () => {
                     )}
                     <div className="detail-movie-platforms">
                       {uniquePlatforms.map((platform) => {
+                        const linkForPlatform =
+                          platform?.direct_link ||
+                          platform?.external_link ||
+                          movieLink;
                         const badgeContent = (
                           <>
                             <img
@@ -455,11 +463,11 @@ const ThematicJourneys = () => {
                           </>
                         );
 
-                        return movieLink ? (
+                        return linkForPlatform ? (
                           <a
                             key={platform?.provider_id || platform?.provider_name}
                             className="platform-badge"
-                            href={movieLink}
+                            href={linkForPlatform}
                             target="_blank"
                             rel="noopener noreferrer"
                           >


### PR DESCRIPTION
## Summary
- scrape TMDB watch pages to capture provider-specific streaming URLs and cache them per movie
- enrich platform payloads with direct links so the frontend can deep link to each provider
- update movie and journey views to prefer provider-level links when rendering platform badges

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf029c0a008323818aef49ea51c746