### PR TITLE
feat: add hero search suggestions

### DIFF
--- a/watchy-frontend/src/components/HeroBanner.css
+++ b/watchy-frontend/src/components/HeroBanner.css
@@ -312,6 +312,91 @@
   max-width: 600px;
 }
 
+.hero-suggestions {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 0;
+  right: 0;
+  background: rgba(20, 20, 20, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  box-shadow:
+    0 20px 35px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+  max-height: 360px;
+  display: flex;
+  flex-direction: column;
+  z-index: 25;
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+.hero-suggestions-empty {
+  padding: 16px 20px;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.7);
+  text-align: center;
+}
+
+.hero-suggestion-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  background: transparent;
+  border: none;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+  color: inherit;
+}
+
+.hero-suggestion-item:hover {
+  background: rgba(0, 255, 136, 0.12);
+  transform: translateX(4px);
+}
+
+.hero-suggestion-image,
+.hero-suggestion-placeholder {
+  width: 52px;
+  height: 78px;
+  border-radius: 10px;
+  object-fit: cover;
+  background: rgba(255, 255, 255, 0.05);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.hero-suggestion-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow: hidden;
+}
+
+.hero-suggestion-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #ffffff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hero-suggestion-meta {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
 .hero-search-input {
   width: 100%;
   padding: 16px 50px 16px 20px;

--- a/watchy-frontend/src/components/HeroBanner.jsx
+++ b/watchy-frontend/src/components/HeroBanner.jsx
@@ -1,21 +1,122 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './HeroBanner.css';
 import logo from '../assets/logo.png';
+import { searchMovies } from '../services/api';
+
+const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w92';
 
 const HeroBanner = ({ title, onSearch }) => {
   const [searchQuery, setSearchQuery] = useState('');
+  const [suggestions, setSuggestions] = useState([]);
+  const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
+  const [isSuggestionOpen, setIsSuggestionOpen] = useState(false);
+  const blurTimeoutRef = useRef(null);
 
   const handleSearch = () => {
-    if (searchQuery.trim() && onSearch) {
-      onSearch(searchQuery);
+    const trimmedQuery = searchQuery.trim();
+
+    if (!trimmedQuery || !onSearch) {
+      return;
     }
+
+    onSearch(trimmedQuery);
+    setSearchQuery(trimmedQuery);
+    setSuggestions([]);
+    setIsSuggestionOpen(false);
   };
 
   const handleKeyPress = (e) => {
     if (e.key === 'Enter') {
+      e.preventDefault();
       handleSearch();
     }
   };
+
+  const handleInputChange = (event) => {
+    const value = event.target.value;
+    setSearchQuery(value);
+
+    if (value.trim().length >= 2) {
+      setIsSuggestionOpen(true);
+    } else {
+      setIsSuggestionOpen(false);
+    }
+  };
+
+  const handleInputFocus = () => {
+    if (blurTimeoutRef.current) {
+      clearTimeout(blurTimeoutRef.current);
+    }
+
+    if (searchQuery.trim().length >= 2 && (suggestions.length || isLoadingSuggestions)) {
+      setIsSuggestionOpen(true);
+    }
+  };
+
+  const handleInputBlur = () => {
+    blurTimeoutRef.current = setTimeout(() => {
+      setIsSuggestionOpen(false);
+    }, 150);
+  };
+
+  const handleSuggestionSelect = (movie) => {
+    if (blurTimeoutRef.current) {
+      clearTimeout(blurTimeoutRef.current);
+    }
+
+    setSearchQuery(movie.title);
+    setSuggestions([]);
+    setIsSuggestionOpen(false);
+
+    if (onSearch) {
+      onSearch(movie.title);
+    }
+  };
+
+  useEffect(() => {
+    const trimmed = searchQuery.trim();
+
+    if (trimmed.length < 2) {
+      setSuggestions([]);
+      setIsLoadingSuggestions(false);
+      return;
+    }
+
+    let isActive = true;
+    setIsLoadingSuggestions(true);
+
+    const debounceId = setTimeout(async () => {
+      try {
+        const results = await searchMovies(trimmed);
+
+        if (!isActive) {
+          return;
+        }
+
+        setSuggestions(results.slice(0, 6));
+      } catch (error) {
+        if (isActive) {
+          console.error('Öneriler alınamadı:', error);
+          setSuggestions([]);
+        }
+      } finally {
+        if (isActive) {
+          setIsLoadingSuggestions(false);
+        }
+      }
+    }, 350);
+
+    return () => {
+      isActive = false;
+      clearTimeout(debounceId);
+    };
+  }, [searchQuery]);
+
+  useEffect(() => () => {
+    if (blurTimeoutRef.current) {
+      clearTimeout(blurTimeoutRef.current);
+    }
+  }, []);
 
   const handleLogin = () => {
     // Login işlemi için handler
@@ -80,14 +181,65 @@ const HeroBanner = ({ title, onSearch }) => {
                 className="hero-search-input"
                 placeholder="Film adı girin..."
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={handleInputChange}
                 onKeyPress={handleKeyPress}
+                onFocus={handleInputFocus}
+                onBlur={handleInputBlur}
               />
               <button className="hero-search-button" onClick={handleSearch}>
                 <svg fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd"></path>
                 </svg>
               </button>
+              {isSuggestionOpen && (
+                <div className="hero-suggestions">
+                  {isLoadingSuggestions && (
+                    <div className="hero-suggestions-empty">Filmler aranıyor...</div>
+                  )}
+
+                  {!isLoadingSuggestions && suggestions.length === 0 && (
+                    <div className="hero-suggestions-empty">Uygun film bulunamadı.</div>
+                  )}
+
+                  {!isLoadingSuggestions && suggestions.map((movie) => {
+                    const posterUrl = movie.poster_path
+                      ? `${TMDB_IMAGE_BASE}${movie.poster_path}`
+                      : null;
+
+                    const releaseYear = movie.release_date
+                      ? new Date(movie.release_date).getFullYear()
+                      : null;
+
+                    return (
+                      <button
+                        key={movie.movie_id}
+                        type="button"
+                        className="hero-suggestion-item"
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={() => handleSuggestionSelect(movie)}
+                      >
+                        {posterUrl ? (
+                          <img
+                            src={posterUrl}
+                            alt={movie.title}
+                            className="hero-suggestion-image"
+                          />
+                        ) : (
+                          <div className="hero-suggestion-placeholder">
+                            {movie.title?.[0] ?? '?'}
+                          </div>
+                        )}
+                        <div className="hero-suggestion-info">
+                          <span className="hero-suggestion-title">{movie.title}</span>
+                          {releaseYear && (
+                            <span className="hero-suggestion-meta">{releaseYear}</span>
+                          )}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- fetch matching movies while typing in the hero search box and display poster-backed suggestions
- allow selecting a suggestion or submitting the trimmed query to trigger a search
- style the suggestion list to match the cinematic hero banner aesthetic

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cf122fff04832381b7c34cb276b06c