### PR TITLE
Support Turkish titles in movie search

### DIFF
--- a/watchy-backend/routes/search.js
+++ b/watchy-backend/routes/search.js
@@ -10,7 +10,7 @@ router.get('/:query', async (req, res) => {
   const query = normalize(rawQuery);
 
   try {
-    const results = await searchMoviesWithCredits(query);
+    const results = await searchMoviesWithCredits(rawQuery, query);
     res.json(results);
   } catch (err) {
     const status = err.response?.status || (err.message === missingCredentialsMessage() ? 500 : err.status) || 500;


### PR DESCRIPTION
## Summary
- switch movie search to TMDB's search endpoint and request results in both Turkish and English
- ensure localized matches are deduplicated and enriched with credits before responding
- forward the raw user query to the TMDB service so language-specific titles can be matched

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf1431e54083239472fbad37e412a9