### PR TITLE
Limit hero search results to selected suggestion

### DIFF
--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -15,8 +15,8 @@ function App() {
   } = useSearch();
 
   // HeroBanner'dan gelen arama işlemi
-  const handleHeroSearch = (searchQuery) => {
-    handleSearch(searchQuery);
+  const handleHeroSearch = (searchPayload) => {
+    handleSearch(searchPayload);
   };
 
   return (

--- a/watchy-frontend/src/components/HeroBanner.css
+++ b/watchy-frontend/src/components/HeroBanner.css
@@ -323,13 +323,28 @@
   box-shadow:
     0 20px 35px rgba(0, 0, 0, 0.6),
     0 0 0 1px rgba(255, 255, 255, 0.05);
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   max-height: 360px;
+  padding: 8px 0;
   display: flex;
   flex-direction: column;
   z-index: 25;
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
+}
+
+.hero-suggestions::-webkit-scrollbar {
+  width: 6px;
+}
+
+.hero-suggestions::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+}
+
+.hero-suggestions::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .hero-suggestions-empty {

--- a/watchy-frontend/src/components/HeroBanner.jsx
+++ b/watchy-frontend/src/components/HeroBanner.jsx
@@ -19,7 +19,7 @@ const HeroBanner = ({ title, onSearch }) => {
       return;
     }
 
-    onSearch(trimmedQuery);
+    onSearch({ query: trimmedQuery });
     setSearchQuery(trimmedQuery);
     setSuggestions([]);
     setIsSuggestionOpen(false);
@@ -69,7 +69,7 @@ const HeroBanner = ({ title, onSearch }) => {
     setIsSuggestionOpen(false);
 
     if (onSearch) {
-      onSearch(movie.title);
+      onSearch({ query: movie.title, movie });
     }
   };
 

--- a/watchy-frontend/src/hooks/useSearch.js
+++ b/watchy-frontend/src/hooks/useSearch.js
@@ -64,12 +64,24 @@ export const useSearch = () => {
   };
 
   const handleSearch = async (searchTerm) => {
-    const effectiveQuery = typeof searchTerm === 'string' ? searchTerm : query;
-    const trimmedQuery = effectiveQuery.trim();
+    const isObjectPayload = typeof searchTerm === 'object' && searchTerm !== null;
+    const selectedMovie = isObjectPayload
+      ? searchTerm.movie || (searchTerm.movie_id ? searchTerm : null)
+      : null;
 
-    if (!trimmedQuery) return;
+    const resolvedQuery = isObjectPayload
+      ? (searchTerm.query || searchTerm.title || selectedMovie?.title || '')
+      : typeof searchTerm === 'string'
+      ? searchTerm
+      : query;
 
-    if (trimmedQuery !== query) {
+    const trimmedQuery = resolvedQuery.trim();
+
+    if (!trimmedQuery && !selectedMovie) {
+      return;
+    }
+
+    if (trimmedQuery && trimmedQuery !== query) {
       setQuery(trimmedQuery);
     }
 
@@ -80,7 +92,7 @@ export const useSearch = () => {
     setLoading(true);
 
     try {
-      const data = await searchMovies(trimmedQuery);
+      const data = selectedMovie ? [selectedMovie] : await searchMovies(trimmedQuery);
       const details = await populateMovieDetails(data);
 
       const availableIds = new Set(


### PR DESCRIPTION
## Summary
- update the hero banner search to send structured payloads for button searches and suggestion selections
- adjust the search hook so that choosing a suggestion only loads that movie while still populating platform data
- allow the hero suggestions dropdown to scroll so all suggested titles remain visible

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cf169184b08323b67398cfcdbb607a