### PR TITLE
Adjust hero banner layout and clear search when browsing

### DIFF
--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -11,7 +11,8 @@ function App() {
     platforms,
     loading,
     hasCompletedSearch,
-    handleSearch
+    handleSearch,
+    resetResults
   } = useSearch();
 
   // HeroBanner'dan gelen arama işlemi
@@ -27,7 +28,7 @@ function App() {
         onSearch={handleHeroSearch}
       />
 
-      <ThematicJourneys />
+      <ThematicJourneys onContentChange={resetResults} />
 
       {/* Yükleniyor durumu */}
       {loading && (

--- a/watchy-frontend/src/components/HeroBanner.css
+++ b/watchy-frontend/src/components/HeroBanner.css
@@ -2,7 +2,7 @@
 
 .hero-banner {
   position: relative;
-  min-height: 400px;
+  min-height: 320px;
   background: #0a0a0a;
   color: white;
   display: flex;
@@ -158,7 +158,7 @@
   z-index: 10;
   width: 90%;
   max-width: 1200px;
-  padding: 50px 60px;
+  padding: 32px 48px;
   background: rgba(20, 20, 20, 0.7);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
@@ -182,13 +182,13 @@
   }
 }
 
-/* Üst header - Logo, Başlık, Login - ÜSTTEN HİZALAMA */
-.hero-header {
+/* Üst satır - Logo, Başlık & Arama, Login */
+.hero-top-row {
   display: flex;
-  align-items: flex-start;  /* ÖNEMLİ: Üstten hizalama */
+  align-items: flex-start;
   justify-content: space-between;
-  margin-bottom: 40px;
-  gap: 30px;
+  width: 100%;
+  gap: 32px;
 }
 
 /* Logo container */
@@ -211,16 +211,24 @@
 }
 
 .hero-logo {
-  height: 100px;  /* LOGO BÜYÜTÜLDÜ */
+  height: 80px;
   object-fit: contain;
   filter: drop-shadow(0 2px 10px rgba(0, 0, 0, 0.5));
 }
 
+.hero-center-stack {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+  align-self: flex-start;
+}
+
 /* Ana başlık */
 .hero-title {
-  flex: 1;
-  text-align: center;
-  padding-top: 15px;  /* Yazıyı logo ile üstten hizalamak için */
+  width: 100%;
 }
 
 .hero-banner h1 {
@@ -255,13 +263,13 @@
   font-weight: 600;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 
+  box-shadow:
     0 4px 15px rgba(0, 255, 136, 0.3),
     inset 0 1px 2px rgba(255, 255, 255, 0.3);
   animation: slideInRight 1s ease-out;
   white-space: nowrap;
   flex-shrink: 0;
-  margin-top: 15px;  /* Butonun üst hizalamasını ayarla */
+  align-self: flex-start;
 }
 
 @keyframes slideInRight {
@@ -291,7 +299,8 @@
 .hero-search-container {
   display: flex;
   justify-content: center;
-  margin-top: 20px;
+  width: 100%;
+  margin-top: 0;
   animation: slideInUp 1.4s ease-out;
 }
 
@@ -310,6 +319,31 @@
   position: relative;
   width: 100%;
   max-width: 600px;
+}
+
+@media (max-width: 900px) {
+  .hero-content-container {
+    padding: 28px 24px;
+    width: 95%;
+  }
+
+  .hero-top-row {
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+  }
+
+  .hero-logo-container {
+    justify-content: center;
+  }
+
+  .hero-center-stack {
+    width: 100%;
+  }
+
+  .hero-login-button {
+    align-self: center;
+  }
 }
 
 .hero-suggestions {
@@ -472,26 +506,15 @@
 /* Mobile responsive */
 @media (max-width: 768px) {
   .hero-banner {
-    min-height: 350px;
+    min-height: 300px;
   }
 
   .hero-content-container {
-    width: 95%;
-    padding: 30px 20px;
-  }
-
-  .hero-header {
-    flex-direction: column;
-    gap: 20px;
-    align-items: center;  /* Mobile'de ortala */
+    padding: 24px 16px;
   }
 
   .hero-logo {
-    height: 70px;  /* Mobile'de logo boyutu */
-  }
-
-  .hero-title {
-    padding-top: 0;
+    height: 64px;
   }
 
   .hero-banner h1 {
@@ -501,7 +524,6 @@
   .hero-login-button {
     padding: 10px 24px;
     font-size: 14px;
-    margin-top: 0;
   }
 
   .film-strip-left,

--- a/watchy-frontend/src/components/HeroBanner.jsx
+++ b/watchy-frontend/src/components/HeroBanner.jsx
@@ -153,95 +153,92 @@ const HeroBanner = ({ title, onSearch }) => {
 
       {/* Ana içerik - glassmorphism container */}
       <div className="hero-content-container">
-        {/* Üst kısım: Logo ve Login */}
-        <div className="hero-header">
+        <div className="hero-top-row">
           {/* Logo */}
           <div className="hero-logo-container">
             <img src={logo} alt="Watchy" className="hero-logo" />
+          </div>
+
+          {/* Başlık ve Arama */}
+          <div className="hero-center-stack">
+            <div className="hero-title">
+              <h1>{highlightTitle(title)}</h1>
+            </div>
+
+            <div className="hero-search-container">
+              <div className="hero-search-box">
+                <input
+                  type="text"
+                  className="hero-search-input"
+                  placeholder="Film adı girin..."
+                  value={searchQuery}
+                  onChange={handleInputChange}
+                  onKeyPress={handleKeyPress}
+                  onFocus={handleInputFocus}
+                  onBlur={handleInputBlur}
+                />
+                <button className="hero-search-button" onClick={handleSearch}>
+                  <svg fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd"></path>
+                  </svg>
+                </button>
+                {isSuggestionOpen && (
+                  <div className="hero-suggestions">
+                    {isLoadingSuggestions && (
+                      <div className="hero-suggestions-empty">Filmler aranıyor...</div>
+                    )}
+
+                    {!isLoadingSuggestions && suggestions.length === 0 && (
+                      <div className="hero-suggestions-empty">Uygun film bulunamadı.</div>
+                    )}
+
+                    {!isLoadingSuggestions && suggestions.map((movie) => {
+                      const posterUrl = movie.poster_path
+                        ? `${TMDB_IMAGE_BASE}${movie.poster_path}`
+                        : null;
+
+                      const releaseYear = movie.release_date
+                        ? new Date(movie.release_date).getFullYear()
+                        : null;
+
+                      return (
+                        <button
+                          key={movie.movie_id}
+                          type="button"
+                          className="hero-suggestion-item"
+                          onMouseDown={(event) => event.preventDefault()}
+                          onClick={() => handleSuggestionSelect(movie)}
+                        >
+                          {posterUrl ? (
+                            <img
+                              src={posterUrl}
+                              alt={movie.title}
+                              className="hero-suggestion-image"
+                            />
+                          ) : (
+                            <div className="hero-suggestion-placeholder">
+                              {movie.title?.[0] ?? '?'}
+                            </div>
+                          )}
+                          <div className="hero-suggestion-info">
+                            <span className="hero-suggestion-title">{movie.title}</span>
+                            {releaseYear && (
+                              <span className="hero-suggestion-meta">{releaseYear}</span>
+                            )}
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
 
           {/* Login butonu */}
           <button className="hero-login-button" onClick={handleLogin}>
             Giriş Yap
           </button>
-        </div>
-
-        {/* Orta kısım: Başlık ve Arama (ortalanmış) */}
-        <div className="hero-center-content">
-          {/* Başlık */}
-          <div className="hero-title">
-            <h1>{highlightTitle(title)}</h1>
-          </div>
-          
-          {/* Arama kutusu */}
-          <div className="hero-search-container">
-            <div className="hero-search-box">
-              <input
-                type="text"
-                className="hero-search-input"
-                placeholder="Film adı girin..."
-                value={searchQuery}
-                onChange={handleInputChange}
-                onKeyPress={handleKeyPress}
-                onFocus={handleInputFocus}
-                onBlur={handleInputBlur}
-              />
-              <button className="hero-search-button" onClick={handleSearch}>
-                <svg fill="currentColor" viewBox="0 0 20 20">
-                  <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd"></path>
-                </svg>
-              </button>
-              {isSuggestionOpen && (
-                <div className="hero-suggestions">
-                  {isLoadingSuggestions && (
-                    <div className="hero-suggestions-empty">Filmler aranıyor...</div>
-                  )}
-
-                  {!isLoadingSuggestions && suggestions.length === 0 && (
-                    <div className="hero-suggestions-empty">Uygun film bulunamadı.</div>
-                  )}
-
-                  {!isLoadingSuggestions && suggestions.map((movie) => {
-                    const posterUrl = movie.poster_path
-                      ? `${TMDB_IMAGE_BASE}${movie.poster_path}`
-                      : null;
-
-                    const releaseYear = movie.release_date
-                      ? new Date(movie.release_date).getFullYear()
-                      : null;
-
-                    return (
-                      <button
-                        key={movie.movie_id}
-                        type="button"
-                        className="hero-suggestion-item"
-                        onMouseDown={(event) => event.preventDefault()}
-                        onClick={() => handleSuggestionSelect(movie)}
-                      >
-                        {posterUrl ? (
-                          <img
-                            src={posterUrl}
-                            alt={movie.title}
-                            className="hero-suggestion-image"
-                          />
-                        ) : (
-                          <div className="hero-suggestion-placeholder">
-                            {movie.title?.[0] ?? '?'}
-                          </div>
-                        )}
-                        <div className="hero-suggestion-info">
-                          <span className="hero-suggestion-title">{movie.title}</span>
-                          {releaseYear && (
-                            <span className="hero-suggestion-meta">{releaseYear}</span>
-                          )}
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          </div>
         </div>
       </div>
     </section>

--- a/watchy-frontend/src/components/thematicjourneys.js
+++ b/watchy-frontend/src/components/thematicjourneys.js
@@ -73,7 +73,7 @@ const DECADE_CONFIGS = [
   }
 ];
 
-const ThematicJourneys = () => {
+const ThematicJourneys = ({ onContentChange }) => {
   const [moviesByDecade, setMoviesByDecade] = useState({});
   const [loading, setLoading] = useState(true);
   const [expandedDecade, setExpandedDecade] = useState(null);
@@ -188,6 +188,10 @@ const ThematicJourneys = () => {
       setExpandedDecade(null);
       setDetailError(null);
       return;
+    }
+
+    if (typeof onContentChange === 'function') {
+      onContentChange();
     }
 
     setExpandedDecade(journey.id);

--- a/watchy-frontend/src/hooks/useSearch.js
+++ b/watchy-frontend/src/hooks/useSearch.js
@@ -154,6 +154,7 @@ export const useSearch = () => {
     showDecades, setShowDecades,
     decades,
     handleSearch,
+    resetResults,
     handleYearSelect,
     hasCompletedSearch
   };


### PR DESCRIPTION
## Summary
- align the hero banner so the logo, search area, and login button share a top row and reduce the banner height for a slimmer appearance
- update the hero banner styling to support the new layout and responsive behavior
- clear search results when thematic journey content is opened so only the active content remains visible

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68cf194ad5688323ad656eaeb5625de3