### PR TITLE
Update hero banner text and reorder decade carousel

### DIFF
--- a/watchy-frontend/src/App.css
+++ b/watchy-frontend/src/App.css
@@ -6,14 +6,14 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-  background-color: #0a0a0a;
-  color: #ffffff;
+  background-color: #ffffff;
+  color: #111827;
   line-height: 1.6;
 }
 
 .App {
   min-height: 100vh;
-  background-color: #0a0a0a;
+  background-color: #ffffff;
 }
 
 /* Header Styles */

--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -21,10 +21,13 @@ function App() {
   };
 
   return (
-    <div className="App" style={{ backgroundColor: 'black', color: 'white', minHeight: '100vh', padding: '20px' }}>
+    <div
+      className="App"
+      style={{ backgroundColor: '#ffffff', color: '#111827', minHeight: '100vh', padding: '20px' }}
+    >
       {/* Sinematik HeroBanner */}
       <HeroBanner
-        title="Sadece izlenebilir ve iyi içerikler!"
+        title="Sadece İZLENEBİLİR ve EN İYİ içerikler!"
         onSearch={handleHeroSearch}
       />
 

--- a/watchy-frontend/src/components/HeroBanner.css
+++ b/watchy-frontend/src/components/HeroBanner.css
@@ -185,7 +185,7 @@
 /* Üst satır - Logo, Başlık & Arama, Login */
 .hero-top-row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   width: 100%;
   gap: clamp(24px, 5vw, 48px);

--- a/watchy-frontend/src/components/HeroBanner.jsx
+++ b/watchy-frontend/src/components/HeroBanner.jsx
@@ -125,12 +125,12 @@ const HeroBanner = ({ title, onSearch }) => {
   };
 
   const highlightTitle = (text) => {
-    const segments = text.split(/(izlenebilir|iyi)/gi);
+    const segments = text.split(/(İZLENEBİLİR|İzlenebilir|izlenebilir|EN İYİ|En İyi|en iyi)/g);
 
     return segments.map((segment, index) => {
-      const lower = segment.toLowerCase();
+      const normalized = segment.toLocaleUpperCase('tr-TR');
 
-      if (lower === 'izlenebilir') {
+      if (normalized === 'İZLENEBİLİR') {
         return (
           <span key={`highlight-izlenebilir-${index}`} className="hero-highlight hero-highlight-watchable">
             {segment}
@@ -138,9 +138,9 @@ const HeroBanner = ({ title, onSearch }) => {
         );
       }
 
-      if (lower === 'iyi') {
+      if (normalized === 'EN İYİ') {
         return (
-          <span key={`highlight-iyi-${index}`} className="hero-highlight hero-highlight-quality">
+          <span key={`highlight-en-iyi-${index}`} className="hero-highlight hero-highlight-quality">
             {segment}
           </span>
         );
@@ -178,7 +178,7 @@ const HeroBanner = ({ title, onSearch }) => {
 
             <p className="hero-note">
               Watchy'de yalnızca şu anda platformlarda bulunan en iyi içerikler var. Platformlarda kaybolma. Watchy'de
-              içeriğine kolayca seç ve izlemeye başla!
+              içeriğini kolayca seç ve izlemeye başla!
             </p>
 
             <div className="hero-search-container">

--- a/watchy-frontend/src/components/thematicjourneys.css
+++ b/watchy-frontend/src/components/thematicjourneys.css
@@ -6,7 +6,7 @@
   font-size: 1.5rem;
   font-weight: 600;
   margin-bottom: 20px;
-  color: #ffffff;
+  color: #0f172a;
 }
 
 .journeys-container {

--- a/watchy-frontend/src/components/thematicjourneys.js
+++ b/watchy-frontend/src/components/thematicjourneys.js
@@ -7,69 +7,60 @@ const POSTER_BASE_URL = 'https://image.tmdb.org/t/p/w185';
 
 const DECADE_CONFIGS = [
   {
-    id: '1960s',
-    title: "1960'lar: Tiffany'de Kahvaltı ve Hitchcock'un Gerilimi",
-    subtitle:"",
-
-    description: "",   period: [1960, 1969],
-    color: '#7c3aed'
-  },
-  {
-    id: '1970s',
-    title: "1970'ler: Baba'nın Teklifi ve Galaksinin Yeni Umudu",
-    subtitle:
-    "",
-    description: "",    period: [1970, 1979],
-    color: '#db2777'
-  },
-  {
-    id: '1980s',
-    title: "1980'ler: Flux Kapasitörlü Neon Rüyası",
-    subtitle:
-      "",
-    description:
-      "",
-    period: [1980, 1989],
-    color: '#2563eb'
-  },
-  {
-    id: '1990s',
-    title: "1990'lar: Dinozorlar, Buzda Güller ve Dijital Rüyalar",
-    subtitle:
-      "",
-    description:
-      "",
-    period: [1990, 1999],
-    color: '#16a34a'
-  },
-  {
-    id: '2000s',
-    title: "2000'ler: Orta Dünya, Hogwarts ve Karayip Dalgalanmaları",
-    subtitle:
-      "",
-    description:
-      "",
-    period: [2000, 2009],
-    color: '#dc2626'
+    id: '2020s',
+    title: "2020'ler",
+    subtitle: '',
+    description: '',
+    period: [2020, 2029],
+    color: '#0ea5e9'
   },
   {
     id: '2010s',
-    title: "2010'lar: Sonsuzluk Eldiveni ve Rüya Katmanları",
-    subtitle:
-      "",
-    description:
-      "",
+    title: "2010'lar",
+    subtitle: '',
+    description: '',
     period: [2010, 2019],
     color: '#f97316'
   },
   {
-    id: '2020s',
-    title: "2020'ler: Kum Fırtınaları, Multiverseler ve Pembeli Devrim",
-    subtitle:
-      "",
-    description: "",
-    period: [2020, 2029],
-    color: '#0ea5e9'
+    id: '2000s',
+    title: "2000'ler",
+    subtitle: '',
+    description: '',
+    period: [2000, 2009],
+    color: '#dc2626'
+  },
+  {
+    id: '1990s',
+    title: "1990'lar",
+    subtitle: '',
+    description: '',
+    period: [1990, 1999],
+    color: '#16a34a'
+  },
+  {
+    id: '1980s',
+    title: "1980'ler",
+    subtitle: '',
+    description: '',
+    period: [1980, 1989],
+    color: '#2563eb'
+  },
+  {
+    id: '1970s',
+    title: "1970'ler",
+    subtitle: '',
+    description: '',
+    period: [1970, 1979],
+    color: '#db2777'
+  },
+  {
+    id: '1960s',
+    title: "1960'lar",
+    subtitle: '',
+    description: '',
+    period: [1960, 1969],
+    color: '#7c3aed'
   }
 ];
 
@@ -301,8 +292,10 @@ const ThematicJourneys = ({ onContentChange }) => {
           >
             <div className="journey-header">
               <h3 className="journey-title">{journey.title}</h3>
-              <h4 className="journey-subtitle">{journey.subtitle}</h4>
-              <p className="journey-description">{journey.description}</p>
+              {journey.subtitle && <h4 className="journey-subtitle">{journey.subtitle}</h4>}
+              {journey.description && (
+                <p className="journey-description">{journey.description}</p>
+              )}
             </div>
             
             {journey.movies.length === 0 ? (
@@ -392,7 +385,9 @@ const ThematicJourneys = ({ onContentChange }) => {
                 {activeJourney.period[0]} – {activeJourney.period[1]}
               </span>
               <h3 className="journey-detail-title">{activeJourney.title}</h3>
-              <p className="journey-detail-subtitle">{activeJourney.subtitle}</p>
+              {activeJourney.subtitle && (
+                <p className="journey-detail-subtitle">{activeJourney.subtitle}</p>
+              )}
             </div>
 
             <button


### PR DESCRIPTION
## Summary
- emphasize the hero headline phrase with uppercase highlights, adjust the supporting note, and align the header elements while keeping the banner dark against a white page background
- reorder the thematic decade configurations to start with the 2020s and simplify their displayed titles

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cf202d6b2083239dce3e74f31d3a38