### PR TITLE
Hide decade section during search and expand suggestions

### DIFF
--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -31,7 +31,7 @@ function App() {
         onSearch={handleHeroSearch}
       />
 
-      <ThematicJourneys onContentChange={resetResults} />
+      {!hasCompletedSearch && <ThematicJourneys onContentChange={resetResults} />}
 
       {/* Yükleniyor durumu */}
       {loading && (

--- a/watchy-frontend/src/components/HeroBanner.css
+++ b/watchy-frontend/src/components/HeroBanner.css
@@ -9,8 +9,8 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  overflow: hidden;
-  padding: 48px 0;
+  overflow: visible;
+  padding: 48px 0 clamp(160px, 28vh, 320px);
   margin: -20px -20px 40px -20px; /* App.js padding'ini nötralize et */
 }
 


### PR DESCRIPTION
## Summary
- hide the decade film recommendations when a search has completed so only the requested results remain visible
- relax the hero banner overflow and add extra bottom padding to ensure the full suggestions list can be seen

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cf22d8b8b483239c9e50abaeaa4ba3