### PR TITLE
Align hero banner with top and adjust page background

### DIFF
--- a/watchy-frontend/src/App.css
+++ b/watchy-frontend/src/App.css
@@ -6,7 +6,7 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-  background-color: #ffffff;
+  background-color: #010a16;
   color: #111827;
   line-height: 1.6;
 }
@@ -14,6 +14,28 @@ body {
 .App {
   min-height: 100vh;
   background-color: #ffffff;
+  color: #111827;
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+}
+
+.app-main {
+  flex: 1;
+  background-color: #ffffff;
+  padding: 0 20px 40px;
+}
+
+.app-loading {
+  text-align: center;
+  padding: 40px;
+  color: #888;
+}
+
+.app-results-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
 }
 
 /* Header Styles */

--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -21,36 +21,31 @@ function App() {
   };
 
   return (
-    <div
-      className="App"
-      style={{ backgroundColor: '#ffffff', color: '#111827', minHeight: '100vh', padding: '20px' }}
-    >
+    <div className="App">
       {/* Sinematik HeroBanner */}
       <HeroBanner
         title="Sadece İZLENEBİLİR ve EN İYİ içerikler!"
         onSearch={handleHeroSearch}
       />
 
-      {!hasCompletedSearch && <ThematicJourneys onContentChange={resetResults} />}
+      <div className="app-main">
+        {!hasCompletedSearch && <ThematicJourneys onContentChange={resetResults} />}
 
-      {/* Yükleniyor durumu */}
-      {loading && (
-        <div style={{ 
-          textAlign: 'center', 
-          padding: '40px',
-          color: '#888'
-        }}>
-          <p>Yükleniyor...</p>
+        {/* Yükleniyor durumu */}
+        {loading && (
+          <div className="app-loading">
+            <p>Yükleniyor...</p>
+          </div>
+        )}
+
+        {/* Sonuçlar */}
+        <div className="app-results-container">
+          <ResultList
+            searchResults={searchResults}
+            platforms={platforms}
+            hasCompletedSearch={hasCompletedSearch}
+          />
         </div>
-      )}
-
-      {/* Sonuçlar */}
-      <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '0 20px' }}>
-        <ResultList
-          searchResults={searchResults}
-          platforms={platforms}
-          hasCompletedSearch={hasCompletedSearch}
-        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- anchor the hero banner to the very top of the page while moving shared layout spacing into dedicated wrappers
- keep the dark hero styling intact and transition the rest of the page to a white background via updated App styles

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cfc2960ea88323b128bc0959a7c3ea