### PR TITLE
Delay loading of period films until user opens section

### DIFF
--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './App.css';
 import ResultList from './components/ResultList';
 import { useSearch } from './hooks/useSearch';
@@ -6,6 +6,8 @@ import HeroBanner from './components/HeroBanner';
 import ThematicJourneys from './components/thematicjourneys';
 
 function App() {
+  const [showThematicJourneys, setShowThematicJourneys] = useState(false);
+  const thematicSectionRef = useRef(null);
   const {
     searchResults,
     platforms,
@@ -20,16 +22,42 @@ function App() {
     handleSearch(searchPayload);
   };
 
+  const scrollToThematicSection = () => {
+    if (thematicSectionRef.current) {
+      thematicSectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
+  const handleFilmsClick = () => {
+    if (showThematicJourneys) {
+      scrollToThematicSection();
+      return;
+    }
+
+    setShowThematicJourneys(true);
+  };
+
+  useEffect(() => {
+    if (showThematicJourneys) {
+      scrollToThematicSection();
+    }
+  }, [showThematicJourneys]);
+
   return (
     <div className="App">
       {/* Sinematik HeroBanner */}
       <HeroBanner
         title="Sadece İZLENEBİLİR ve EN İYİ içerikler!"
         onSearch={handleHeroSearch}
+        onFilmsClick={handleFilmsClick}
       />
 
       <div className="app-main">
-        {!hasCompletedSearch && <ThematicJourneys onContentChange={resetResults} />}
+        {!hasCompletedSearch && showThematicJourneys && (
+          <div id="filmler" ref={thematicSectionRef}>
+            <ThematicJourneys onContentChange={resetResults} />
+          </div>
+        )}
 
         {/* Yükleniyor durumu */}
         {loading && (

--- a/watchy-frontend/src/components/HeroBanner.jsx
+++ b/watchy-frontend/src/components/HeroBanner.jsx
@@ -5,12 +5,19 @@ import { searchMovies } from '../services/api';
 
 const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w92';
 
-const HeroBanner = ({ title, onSearch }) => {
+const HeroBanner = ({ title, onSearch, onFilmsClick }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [suggestions, setSuggestions] = useState([]);
   const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
   const [isSuggestionOpen, setIsSuggestionOpen] = useState(false);
   const blurTimeoutRef = useRef(null);
+
+  const handleFilmsNavClick = (event) => {
+    if (typeof onFilmsClick === 'function') {
+      event.preventDefault();
+      onFilmsClick();
+    }
+  };
 
   const handleSearch = () => {
     const trimmedQuery = searchQuery.trim();
@@ -154,7 +161,13 @@ const HeroBanner = ({ title, onSearch }) => {
             </div>
 
             <nav className="hero-navigation" aria-label="Ana menü">
-              <a href="#filmler" className="hero-nav-link">Filmler</a>
+              <a
+                href="#filmler"
+                className="hero-nav-link"
+                onClick={handleFilmsNavClick}
+              >
+                Filmler
+              </a>
               <a href="#diziler" className="hero-nav-link">Diziler</a>
               <a href="#kisiler" className="hero-nav-link">Kişiler</a>
               <a href="#daha-fazla" className="hero-nav-link">Daha Fazla</a>


### PR DESCRIPTION
## Summary
- gate the Dönem Filmleri component behind an explicit "Filmler" banner click so it no longer loads on initial render
- add smooth scrolling that focuses the section when it becomes visible
- wire the hero navigation link to trigger the reveal instead of immediately following the anchor

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cfca29dc2883239f5dc92d1a31a6ad