### PR TITLE
Add director filmography detail view

### DIFF
--- a/watchy-backend/routes/searchByDirector.js
+++ b/watchy-backend/routes/searchByDirector.js
@@ -1,0 +1,50 @@
+const express = require('express');
+
+const router = express.Router();
+
+const { getMoviesByDirector } = require('../services/tmdbService');
+const { missingCredentialsMessage } = require('../config/tmdb');
+
+router.get('/:directorId', async (req, res) => {
+  const { directorId: rawDirectorId } = req.params;
+
+  const directorId = Number.parseInt(rawDirectorId, 10);
+  if (!Number.isFinite(directorId)) {
+    return res.status(400).json({ error: 'Geçerli bir yönetmen kimliği sağlamalısınız.' });
+  }
+
+  try {
+    const movies = await getMoviesByDirector(directorId);
+    return res.json(movies);
+  } catch (error) {
+    const status =
+      error.response?.status ||
+      (error.message === missingCredentialsMessage() ? 500 : error.status) ||
+      500;
+    const details = error.response?.data?.status_message || error.message;
+
+    console.error('🔴 Yönetmen filmleri alınamadı:', details);
+
+    if (error.message === missingCredentialsMessage()) {
+      return res.status(500).json({ error: error.message });
+    }
+
+    if (status === 404) {
+      return res.status(404).json({ error: 'Yönetmen bulunamadı.' });
+    }
+
+    if (status === 401) {
+      return res
+        .status(401)
+        .json({ error: 'TMDB kimlik doğrulaması başarısız. Lütfen API ayarlarınızı kontrol edin.' });
+    }
+
+    if (status === 400) {
+      return res.status(400).json({ error: 'Yönetmen filmografisi alınamadı.' });
+    }
+
+    return res.status(500).json({ error: 'Yönetmen filmleri alınırken bir hata oluştu.' });
+  }
+});
+
+module.exports = router;

--- a/watchy-backend/server.js
+++ b/watchy-backend/server.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const searchRoute = require('./routes/search');
 const searchByYearRoute = require('./routes/searchByYear');
 const searchByPeriodRoute = require('./routes/searchByPeriod');
+const searchByDirectorRoute = require('./routes/searchByDirector');
 const platformsRoute = require('./routes/platforms');
 const moviesRoute = require('./routes/movies');
 
@@ -13,11 +14,12 @@ const PORT = process.env.PORT || 4000;
 app.use(cors());
 
 // API rotalarını tanımla
-app.use('/api/search/year', searchByYearRoute);   // Örn: /api/search/year/:year
-app.use('/api/search/period', searchByPeriodRoute); // Örn: /api/search/period?from=YYYY&to=YYYY
-app.use('/api/search', searchRoute);              // Örn: /api/search/:query
-app.use('/api/platforms', platformsRoute);        // Örn: /api/platforms/:movieId
-app.use('/api/movies', moviesRoute);              // Örn: /api/movies/decade?start=YYYY&end=YYYY
+app.use('/api/search/year', searchByYearRoute);      // Örn: /api/search/year/:year
+app.use('/api/search/period', searchByPeriodRoute);  // Örn: /api/search/period?from=YYYY&to=YYYY
+app.use('/api/search/director', searchByDirectorRoute); // Örn: /api/search/director/:directorId
+app.use('/api/search', searchRoute);                 // Örn: /api/search/:query
+app.use('/api/platforms', platformsRoute);           // Örn: /api/platforms/:movieId
+app.use('/api/movies', moviesRoute);                 // Örn: /api/movies/decade?start=YYYY&end=YYYY
 
 // Sunucuyu başlat
 app.listen(PORT, () => {

--- a/watchy-frontend/src/services/api.js
+++ b/watchy-frontend/src/services/api.js
@@ -67,3 +67,14 @@ export const getTopMoviesByDecade = (start, end, limit = 3) => {
     'On yıllık döneme göre film araması başarısız'
   );
 };
+
+export const searchMoviesByDirector = (directorId) => {
+  if (directorId == null || directorId === '') {
+    return Promise.resolve([]);
+  }
+
+  return fetchJson(
+    `/search/director/${encodeURIComponent(directorId)}`,
+    'Yönetmene göre film arama başarısız'
+  );
+};


### PR DESCRIPTION
## Summary
- add a backend endpoint that returns movies for a TMDB director id and expose it via the API router
- expose a frontend service helper to query the new endpoint
- update the thematic journeys section so director cards can be selected to load and display platform-ready films with detailed info, matching the decade flow

## Testing
- npm --prefix watchy-frontend test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d03f9b0a2883238847050bd0c8228f