### PR TITLE
Add Hollywood actors section with TMDB portraits

### DIFF
--- a/watchy-frontend/src/components/thematicjourneys.css
+++ b/watchy-frontend/src/components/thematicjourneys.css
@@ -20,6 +20,59 @@
   margin-top: 12px;
 }
 
+.actors-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 20px;
+  margin-top: 16px;
+}
+
+.actor-card {
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.22);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  color: #f8fafc;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.actor-card:hover,
+.actor-card:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 40px rgba(15, 23, 42, 0.32);
+}
+
+.actor-card:focus-visible {
+  outline: 3px solid rgba(148, 163, 184, 0.75);
+  outline-offset: 4px;
+}
+
+.actor-photo-wrapper {
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 14px;
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.actor-photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.actor-name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
 .journey-card {
   flex: 0 0 300px;
   padding: 24px;

--- a/watchy-frontend/src/components/thematicjourneys.js
+++ b/watchy-frontend/src/components/thematicjourneys.js
@@ -4,6 +4,7 @@ import './thematicjourneys.css';
 import { getPlatforms, searchMoviesByPeriod, searchMoviesByDirector } from '../services/api';
 
 const POSTER_BASE_URL = 'https://image.tmdb.org/t/p/w185';
+const PROFILE_BASE_URL = 'https://image.tmdb.org/t/p/w300_and_h450_bestv2';
 
 const DECADE_CONFIGS = [
   {
@@ -344,6 +345,69 @@ const DIRECTOR_CARDS = [
         platforms: []
       }
     ]
+  }
+];
+
+const ACTOR_CARDS = [
+  {
+    id: 'tom-cruise',
+    tmdbId: 500,
+    name: 'Tom Cruise',
+    profilePath: '/3mShHjSQR7NXOVbdTu5rT2Qd0MN.jpg'
+  },
+  {
+    id: 'robert-downey-jr',
+    tmdbId: 3223,
+    name: 'Robert Downey Jr.',
+    profilePath: '/5qHNjhtjMD4YWH3UP0rm4tKwxCL.jpg'
+  },
+  {
+    id: 'scarlett-johansson',
+    tmdbId: 1245,
+    name: 'Scarlett Johansson',
+    profilePath: '/mjReG6rR7NPMEIWb1T4YWtV11ty.jpg'
+  },
+  {
+    id: 'leonardo-dicaprio',
+    tmdbId: 6193,
+    name: 'Leonardo DiCaprio',
+    profilePath: '/wo2hJpn04vbtmh0B9utCFdsQhxM.jpg'
+  },
+  {
+    id: 'dwayne-johnson',
+    tmdbId: 18918,
+    name: 'Dwayne Johnson',
+    profilePath: '/5QApZVV8FUFlVxQpIK3Ew6cqotq.jpg'
+  },
+  {
+    id: 'jennifer-lawrence',
+    tmdbId: 72129,
+    name: 'Jennifer Lawrence',
+    profilePath: '/k6CsASaySnS3ag0Y2Ns2vqPahVn.jpg'
+  },
+  {
+    id: 'brad-pitt',
+    tmdbId: 287,
+    name: 'Brad Pitt',
+    profilePath: '/9OfnD7lxgIj3BNQpJFnwxnwl6w5.jpg'
+  },
+  {
+    id: 'chris-hemsworth',
+    tmdbId: 74568,
+    name: 'Chris Hemsworth',
+    profilePath: '/piQGdoIQOF3C1EI5cbYZLAW1gfj.jpg'
+  },
+  {
+    id: 'angelina-jolie',
+    tmdbId: 11701,
+    name: 'Angelina Jolie',
+    profilePath: '/bXNxIKcJ5cNNW8QFrBPWcfTSu9x.jpg'
+  },
+  {
+    id: 'keanu-reeves',
+    tmdbId: 6384,
+    name: 'Keanu Reeves',
+    profilePath: '/8RZLOyYGsoRe9p44q3xin9QkMHv.jpg'
   }
 ];
 
@@ -1045,6 +1109,23 @@ const ThematicJourneys = ({ onContentChange }) => {
           )}
         </div>
       )}
+
+      <h2 className="section-title">Oyuncular</h2>
+      <div className="actors-grid">
+        {ACTOR_CARDS.map((actor) => (
+          <article key={actor.id} className="actor-card">
+            <div className="actor-photo-wrapper">
+              <img
+                src={`${PROFILE_BASE_URL}${actor.profilePath}`}
+                alt={`${actor.name} portresi`}
+                className="actor-photo"
+                loading="lazy"
+              />
+            </div>
+            <h3 className="actor-name">{actor.name}</h3>
+          </article>
+        ))}
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- add a static list of top Hollywood actors sourced from TMDB profile images
- render a new "Oyuncular" grid beneath the directors section inside the thematic journeys view
- style the actor cards with a responsive grid and portrait presentation

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d10ccd0abc8323825ecfb1b9d22185