### PR TITLE
Add actor filmography view and gate people sections

### DIFF
--- a/watchy-backend/routes/searchByActor.js
+++ b/watchy-backend/routes/searchByActor.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const { getMoviesByActor } = require('../services/tmdbService');
+
+const router = express.Router();
+
+router.get('/:actorId', async (req, res) => {
+  const { actorId: rawActorId } = req.params;
+  const actorId = Number.parseInt(rawActorId, 10);
+
+  if (!Number.isFinite(actorId)) {
+    res.status(400).json({ error: 'Geçersiz oyuncu kimliği.' });
+    return;
+  }
+
+  try {
+    const movies = await getMoviesByActor(actorId);
+    res.json(Array.isArray(movies) ? movies : []);
+  } catch (error) {
+    console.error('🎬 Oyuncuya göre arama hatası:', error?.message || error);
+    res.status(500).json({ error: 'Oyuncu filmografisi alınamadı.' });
+  }
+});
+
+module.exports = router;

--- a/watchy-backend/server.js
+++ b/watchy-backend/server.js
@@ -5,6 +5,7 @@ const searchRoute = require('./routes/search');
 const searchByYearRoute = require('./routes/searchByYear');
 const searchByPeriodRoute = require('./routes/searchByPeriod');
 const searchByDirectorRoute = require('./routes/searchByDirector');
+const searchByActorRoute = require('./routes/searchByActor');
 const platformsRoute = require('./routes/platforms');
 const moviesRoute = require('./routes/movies');
 
@@ -17,6 +18,7 @@ app.use(cors());
 app.use('/api/search/year', searchByYearRoute);      // Örn: /api/search/year/:year
 app.use('/api/search/period', searchByPeriodRoute);  // Örn: /api/search/period?from=YYYY&to=YYYY
 app.use('/api/search/director', searchByDirectorRoute); // Örn: /api/search/director/:directorId
+app.use('/api/search/actor', searchByActorRoute);       // Örn: /api/search/actor/:actorId
 app.use('/api/search', searchRoute);                 // Örn: /api/search/:query
 app.use('/api/platforms', platformsRoute);           // Örn: /api/platforms/:movieId
 app.use('/api/movies', moviesRoute);                 // Örn: /api/movies/decade?start=YYYY&end=YYYY

--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -8,6 +8,8 @@ import ThematicJourneys from './components/thematicjourneys';
 function App() {
   const [showThematicJourneys, setShowThematicJourneys] = useState(false);
   const thematicSectionRef = useRef(null);
+  const [showPeopleSections, setShowPeopleSections] = useState(false);
+  const peopleSectionRef = useRef(null);
   const {
     searchResults,
     platforms,
@@ -28,6 +30,12 @@ function App() {
     }
   };
 
+  const scrollToPeopleSection = () => {
+    if (peopleSectionRef.current) {
+      peopleSectionRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
   const handleFilmsClick = () => {
     if (showThematicJourneys) {
       scrollToThematicSection();
@@ -37,11 +45,30 @@ function App() {
     setShowThematicJourneys(true);
   };
 
+  const handlePeopleClick = () => {
+    if (!showThematicJourneys) {
+      setShowThematicJourneys(true);
+    }
+
+    if (!showPeopleSections) {
+      setShowPeopleSections(true);
+      return;
+    }
+
+    scrollToPeopleSection();
+  };
+
   useEffect(() => {
     if (showThematicJourneys) {
       scrollToThematicSection();
     }
   }, [showThematicJourneys]);
+
+  useEffect(() => {
+    if (showThematicJourneys && showPeopleSections) {
+      scrollToPeopleSection();
+    }
+  }, [showThematicJourneys, showPeopleSections]);
 
   return (
     <div className="App">
@@ -50,12 +77,17 @@ function App() {
         title="Sadece İZLENEBİLİR ve EN İYİ içerikler!"
         onSearch={handleHeroSearch}
         onFilmsClick={handleFilmsClick}
+        onPeopleClick={handlePeopleClick}
       />
 
       <div className="app-main">
         {!hasCompletedSearch && showThematicJourneys && (
           <div id="filmler" ref={thematicSectionRef}>
-            <ThematicJourneys onContentChange={resetResults} />
+            <ThematicJourneys
+              onContentChange={resetResults}
+              showPeopleSections={showPeopleSections}
+              peopleSectionRef={peopleSectionRef}
+            />
           </div>
         )}
 

--- a/watchy-frontend/src/components/HeroBanner.jsx
+++ b/watchy-frontend/src/components/HeroBanner.jsx
@@ -5,7 +5,7 @@ import { searchMovies } from '../services/api';
 
 const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w92';
 
-const HeroBanner = ({ title, onSearch, onFilmsClick }) => {
+const HeroBanner = ({ title, onSearch, onFilmsClick, onPeopleClick }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [suggestions, setSuggestions] = useState([]);
   const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
@@ -16,6 +16,13 @@ const HeroBanner = ({ title, onSearch, onFilmsClick }) => {
     if (typeof onFilmsClick === 'function') {
       event.preventDefault();
       onFilmsClick();
+    }
+  };
+
+  const handlePeopleNavClick = (event) => {
+    if (typeof onPeopleClick === 'function') {
+      event.preventDefault();
+      onPeopleClick();
     }
   };
 
@@ -169,7 +176,9 @@ const HeroBanner = ({ title, onSearch, onFilmsClick }) => {
                 Filmler
               </a>
               <a href="#diziler" className="hero-nav-link">Diziler</a>
-              <a href="#kisiler" className="hero-nav-link">Kişiler</a>
+              <a href="#kisiler" className="hero-nav-link" onClick={handlePeopleNavClick}>
+                Kişiler
+              </a>
               <a href="#daha-fazla" className="hero-nav-link">Daha Fazla</a>
             </nav>
           </div>

--- a/watchy-frontend/src/components/thematicjourneys.css
+++ b/watchy-frontend/src/components/thematicjourneys.css
@@ -27,6 +27,13 @@
   margin-top: 16px;
 }
 
+.people-section {
+  margin-top: 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
 .actor-card {
   background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
   border-radius: 16px;
@@ -38,12 +45,18 @@
   text-align: center;
   color: #f8fafc;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
+  cursor: pointer;
 }
 
 .actor-card:hover,
 .actor-card:focus-visible {
   transform: translateY(-6px);
   box-shadow: 0 24px 40px rgba(15, 23, 42, 0.32);
+}
+
+.actor-card--active {
+  transform: translateY(-8px);
+  box-shadow: 0 28px 46px rgba(15, 23, 42, 0.4);
 }
 
 .actor-card:focus-visible {
@@ -65,6 +78,16 @@
   height: 100%;
   object-fit: cover;
   display: block;
+}
+
+.actor-photo-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.4rem;
+  color: rgba(226, 232, 240, 0.75);
 }
 
 .actor-name {

--- a/watchy-frontend/src/services/api.js
+++ b/watchy-frontend/src/services/api.js
@@ -78,3 +78,14 @@ export const searchMoviesByDirector = (directorId) => {
     'Yönetmene göre film arama başarısız'
   );
 };
+
+export const searchMoviesByActor = (actorId) => {
+  if (actorId == null || actorId === '') {
+    return Promise.resolve([]);
+  }
+
+  return fetchJson(
+    `/search/actor/${encodeURIComponent(actorId)}`,
+    'Oyuncuya göre film arama başarısız'
+  );
+};


### PR DESCRIPTION
## Summary
- add a backend endpoint to return filmographies for specific actors
- reveal the director and actor areas only when the people navigation is invoked and show actor film details on selection
- expand the curated actor list to twenty entries and adjust styling for interactive cards

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d1342a7ddc83238f0a7741b1cdcc08