### PR TITLE
Ensure menu toggles hide previous content

### DIFF
--- a/watchy-frontend/src/App.js
+++ b/watchy-frontend/src/App.js
@@ -42,6 +42,10 @@ function App() {
       setShowThematicJourneys(true);
     }
 
+    if (showPeopleSections) {
+      setShowPeopleSections(false);
+    }
+
     if (!showPeriodSections) {
       setShowPeriodSections(true);
       return;


### PR DESCRIPTION
## Summary
- hide the people section when switching back to films from the top navigation

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d2f001e74c8323a20fe1e83de7a1cf